### PR TITLE
rebranding the api to use exosx

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 #
 # Local testing parameters - replace <variables> with correct values, do not commit!
 #
-STORAGEIP=http://10.235.212.193
-TEST_USERNAME=manage
-TEST_PASSWORD=Testit123!
+STORAGEIP=http:<ipaddress>
+TEST_USERNAME=<username>
+TEST_PASSWORD=<password>

--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+#
+# Local testing parameters - replace <variables> with correct values, do not commit!
+#
+STORAGEIP=http://10.235.212.193
+TEST_USERNAME=manage
+TEST_PASSWORD=Testit123!

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ test:
 
 semantic-release:
   stage: release
-  image: enix/semantic-release:gitlab
+  image: seagate/semantic-release:gitlab
   script:
     - npx semantic-release --ci
   only:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,4 +1,4 @@
-repositoryUrl: git@github.com:enix/dothill-api-go.git
+repositoryUrl: git@github.com:Seagate/seagate-exos-x-api-go.git
 plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2019 Enix SAS
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE.old
+++ b/LICENSE.old
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Enix SAS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ This option runs the Go language test cases against a live storage system. Two s
 - Update .env with the correct system IP Address and credentials
 - Run `go test -v`
 
+Another option is to define environment variables, which take precedence over .env values
+- export TEST_STORAGEIP=http:/<ipaddress>
+- export TEST_USERNAME=<username>
+- export TEST_USERNAME=<password>
+- Run `go test -v`
+- unset TEST_STORAGEIP TEST_PASSWORD TEST_USERNAME
+
 
 ## Test Using a Mock Server
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
-# dothill-api-go
+# seagate-exos-x-api-go
 
-[![Build status](https://gitlab.com/enix.io/dothill-api-go/badges/master/pipeline.svg)](https://gitlab.com/enix.io/dothill-api-go/-/pipelines)
-[![Go Report Card](https://goreportcard.com/badge/github.com/enix/dothill-api-go)](https://goreportcard.com/report/github.com/enix/dothill-api-go)
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/enix/dothill-api-go)](https://pkg.go.dev/github.com/enix/dothill-api-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Seagate/seagate-exos-x-api-go)](https://goreportcard.com/report/github.com/Seagate/seagate-exos-x-api-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Seagate/seagate-exos-x-api-go.svg)](https://pkg.go.dev/github.com/Seagate/seagate-exos-x-api-go)
 
-A Go implementation of the [Dothill API](https://www.seagate.com/files/dothill-content/support/documentation/AssuredSAN_4004_Series_CLI_Reference_Guide_GL105.pdf).
+A Go implementation of the [Seagate EXOS X API](https://www.seagate.com/files/www-content/support-content/raid-systems/_shared/documentation/83-00007047-13-01_G265_SMG.pdf).
 
-## Run tests
+## Test Using A Live System
 
-In order to run tests, you will need to install node.js and npm to run the mock server. When it's done, go to the `mock` directory, install dependencies and start the mock server.
+This option runs the Go language test cases against a live storage system. Two steps are required:
+- Update .env with the correct system IP Address and credentials
+- Run `go test -v`
+
+
+## Test Using a Mock Server
+
+### Using node.js
+
+You can run tests with docker-compose:
+
+```sh
+docker-compose up --build --abort-on-container-exit --exit-code-from tests
+```
+
+### Using node.js
+
+In order to run tests against a mock server, you will need to install node.js and npm to run the mock server. When it's done, go to the `mock` directory, install dependencies and start the mock server.
 
 ```sh
 cd ./mock
@@ -16,10 +32,6 @@ npm install
 npm run start
 ```
 
-You're now ready to go, just run `go test` to run the tests suite.
+- Update .env with an IP Address of `localhost:8080` and correct credentials
+- You're now ready to go, just run `go test -v` to run the tests suite.
 
-You can also skip previous steps and just run tests with docker-compose:
-
-```sh
-docker-compose up --build --abort-on-container-exit --exit-code-from tests
-```

--- a/endpoints.go
+++ b/endpoints.go
@@ -1,22 +1,39 @@
-package dothill
+package exosx
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 )
 
 // Login : Called automatically, may be called manually if credentials changed
-func (client *Client) Login() error {
+func (client *Client) Login(hashf ...string) error {
 	userpass := fmt.Sprintf("%s_%s", client.Username, client.Password)
-	hash := md5.Sum([]byte(userpass))
-	res, _, err := client.FormattedRequest("/login/%x", hash)
+
+	var hashmethod string = "md5"
+	if len(hashf) > 0 {
+		hashmethod = hashf[0]
+	}
+
+	var hash string
+	if hashmethod == "md5" {
+		hash = fmt.Sprintf("%x", md5.Sum([]byte(userpass)))
+	} else if hashmethod == "sha256" {
+		hasher := sha256.New()
+		hasher.Write([]byte(userpass))
+		hash = fmt.Sprintf("%x", hasher.Sum(nil))
+	} else {
+		return fmt.Errorf("Login: hash function (%s) not supported, try: md5, sha256", hashmethod)
+	}
+
+	res, _, err := client.FormattedRequest("/login/%s", hash)
 
 	if err != nil {
 		return err
 	}
 
-	client.sessionKey = res.ObjectsMap["status"].PropertiesMap["response"].Data
+	client.SessionKey = res.ObjectsMap["status"].PropertiesMap["response"].Data
 	return nil
 }
 

--- a/endpoints.go
+++ b/endpoints.go
@@ -2,31 +2,14 @@ package exosx
 
 import (
 	"crypto/md5"
-	"crypto/sha256"
 	"fmt"
 	"strings"
 )
 
 // Login : Called automatically, may be called manually if credentials changed
-func (client *Client) Login(hashf ...string) error {
+func (client *Client) Login() error {
 	userpass := fmt.Sprintf("%s_%s", client.Username, client.Password)
-
-	var hashmethod string = "md5"
-	if len(hashf) > 0 {
-		hashmethod = hashf[0]
-	}
-
-	var hash string
-	if hashmethod == "md5" {
-		hash = fmt.Sprintf("%x", md5.Sum([]byte(userpass)))
-	} else if hashmethod == "sha256" {
-		hasher := sha256.New()
-		hasher.Write([]byte(userpass))
-		hash = fmt.Sprintf("%x", hasher.Sum(nil))
-	} else {
-		return fmt.Errorf("Login: hash function (%s) not supported, try: md5, sha256", hashmethod)
-	}
-
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(userpass)))
 	res, _, err := client.FormattedRequest("/login/%s", hash)
 
 	if err != nil {

--- a/exosx.go
+++ b/exosx.go
@@ -1,4 +1,4 @@
-package dothill
+package exosx
 
 import (
 	"crypto/tls"
@@ -11,17 +11,17 @@ import (
 	"k8s.io/klog"
 )
 
-// Client : Can be used to request the dothill API
+// Client : Can be used to request the API
 type Client struct {
 	Username   string
 	Password   string
 	Addr       string
 	HTTPClient http.Client
 	Collector  *Collector
-	sessionKey string
+	SessionKey string
 }
 
-// NewClient : Creates a dothill client by setting up its HTTP client
+// NewClient : Creates an API client by setting up its HTTP transport
 func NewClient() *Client {
 	return &Client{
 		HTTPClient: http.Client{
@@ -60,7 +60,7 @@ func (client *Client) FormattedRequest(endpointFormat string, opts ...interface{
 func (client *Client) request(req *Request) (*Response, *ResponseStatus, error) {
 	isLoginReq := strings.Contains(req.Endpoint, "login")
 	if !isLoginReq {
-		if len(client.sessionKey) == 0 {
+		if len(client.SessionKey) == 0 {
 			klog.V(1).Info("no session key stored, authenticating before sending request")
 			err := client.Login()
 			if err != nil {
@@ -103,7 +103,7 @@ func (client *Client) request(req *Request) (*Response, *ResponseStatus, error) 
 		klog.Infof("<- [%d %s] <hidden>", status.ReturnCode, status.ResponseType)
 	}
 	if status.ResponseTypeNumeric != 0 {
-		return res, status, fmt.Errorf("Dothill API returned non-zero code %d (%s)", status.ReturnCode, status.Response)
+		return res, status, fmt.Errorf("API returned non-zero code %d (%s)", status.ReturnCode, status.Response)
 	}
 
 	return res, status, nil

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/enix/dothill-api-go
+module github.com/seagate/seagate-exos-x-api-go
 
-go 1.12
+go 1.16
 
 require (
+	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.10.5
 	github.com/prometheus/client_golang v1.10.0
 	k8s.io/klog v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -89,6 +90,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -126,6 +128,8 @@ github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -140,8 +144,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -173,12 +179,14 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -362,6 +370,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -391,12 +400,14 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/main_test.go
+++ b/main_test.go
@@ -12,16 +12,33 @@ import (
 var client = NewClient()
 
 func init() {
+	var exists bool
 	settingsfile := ".env"
-	err := godotenv.Load(settingsfile)
-	if err != nil {
-		fmt.Printf("Error loading file (%s), error: %v\n", settingsfile, err)
-		return
+
+	// Note, any defined environment variable is used over the ones defined in .env
+	if _, err := os.Stat(settingsfile); err == nil {
+		fmt.Printf("Testing setup: Loading (%s)\n", settingsfile)
+		err := godotenv.Load(settingsfile)
+		if err != nil {
+			fmt.Printf("Error loading file (%s), error: %v\n", settingsfile, err)
+			return
+		}
 	}
 
-	client.Addr = os.Getenv("STORAGEIP")
-	client.Username = os.Getenv("TEST_USERNAME")
-	client.Password = os.Getenv("TEST_PASSWORD")
+	client.Addr, exists = os.LookupEnv("TEST_STORAGEIP")
+	if exists {
+		fmt.Printf("Testing setup: %s=%s\n", "TEST_STORAGEIP", client.Addr)
+	}
+
+	client.Username, exists = os.LookupEnv("TEST_USERNAME")
+	if exists {
+		fmt.Printf("Testing setup: %s=%s\n", "TEST_USERNAME", client.Username)
+	}
+
+	client.Password, exists = os.LookupEnv("TEST_PASSWORD")
+	if exists {
+		fmt.Printf("Testing setup: %s=%s\n", "TEST_PASSWORD", client.Password)
+	}
 }
 
 func assert(t *testing.T, cond bool, msg string) {
@@ -32,13 +49,9 @@ func assert(t *testing.T, cond bool, msg string) {
 	}
 }
 
-func TestLoginG(t *testing.T) {
+func TestLogin(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(client.Login()).To(BeNil())
-}
-func TestLoginI(t *testing.T) {
-	g := NewWithT(t)
-	g.Expect(client.Login("sha256")).To(BeNil())
 }
 
 func TestLoginFailed(t *testing.T) {
@@ -47,7 +60,7 @@ func TestLoginFailed(t *testing.T) {
 	wrongClient.Username = client.Username
 	wrongClient.Password = "wrongpassword"
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	g.Expect(wrongClient.Login()).ToNot(BeNil())
 }
 
@@ -57,7 +70,7 @@ func TestReLoginFailed(t *testing.T) {
 	wrongClient.Username = client.Username
 	wrongClient.Password = client.Password
 
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	g.Expect(wrongClient.Login()).To(BeNil())
 
 	wrongClient.Password = "wrongpassword"
@@ -66,11 +79,12 @@ func TestReLoginFailed(t *testing.T) {
 	_, status, err := wrongClient.Request("/status/code/1")
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
-	g.Expect(status.Response).To(Equal("request failed"))
+	// This test returns one of two different values based on the  API version, either: 'request failed' or 'Invalid sessionkey'
+	g.Expect(status.Response).Should(BeElementOf([]string{"request failed", "Invalid sessionkey"}))
 }
 
 func TestInvalidURL(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	_, status, err := client.Request("/trololol")
 
 	g.Expect(err).NotTo(BeNil())
@@ -79,7 +93,7 @@ func TestInvalidURL(t *testing.T) {
 }
 
 func TestInvalidXML(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	_, status, err := client.Request("/invalid/xml")
 
 	g.Expect(err).NotTo(BeNil())
@@ -88,7 +102,7 @@ func TestInvalidXML(t *testing.T) {
 }
 
 func TestStatusCodeNotZero(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 	_, status, err := client.Request("/status/code/1")
 
 	g.Expect(err).NotTo(BeNil())

--- a/metrics.go
+++ b/metrics.go
@@ -1,4 +1,4 @@
-package dothill
+package exosx
 
 import (
 	"fmt"
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	APICallMetric = "dothill_api_appliance_api_call"
+	APICallMetric = "exosx_api_appliance_api_call"
 	APICallHelp   = "How many API calls have been executed"
 
-	APICallDurationMetric = "dothill_api_appliance_api_call_duration"
+	APICallDurationMetric = "exosx_api_appliance_api_call_duration"
 	APICallDurationHelp   = "The total duration of API calls"
 )
 

--- a/mock/package-lock.json
+++ b/mock/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dothill-api-mock-server",
+  "name": "exosx-api-mock-server",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "dothill-api-mock-server",
+  "name": "exosx-api-mock-server",
   "version": "1.0.0",
   "main": "index.js",
-  "author": "Arthur Chaloin",
-  "license": "MIT",
+  "license": "Apache 2.0",
   "dependencies": {
     "express": "^4.16.4",
     "md5": "^2.2.1"

--- a/models.go
+++ b/models.go
@@ -1,4 +1,4 @@
-package dothill
+package exosx
 
 import "strconv"
 

--- a/request.go
+++ b/request.go
@@ -20,6 +20,7 @@ func (req *Request) execute(client *Client) ([]byte, int, error) {
 	}
 
 	httpReq.Header.Set("sessionKey", client.SessionKey)
+	httpReq.SetBasicAuth(client.Username, client.Password)
 	res, err := client.HTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, 0, err

--- a/request.go
+++ b/request.go
@@ -1,4 +1,4 @@
-package dothill
+package exosx
 
 import (
 	"fmt"
@@ -19,7 +19,7 @@ func (req *Request) execute(client *Client) ([]byte, int, error) {
 		return nil, 0, err
 	}
 
-	httpReq.Header.Set("sessionKey", client.sessionKey)
+	httpReq.Header.Set("sessionKey", client.SessionKey)
 	res, err := client.HTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, 0, err

--- a/response.go
+++ b/response.go
@@ -1,4 +1,4 @@
-package dothill
+package exosx
 
 import (
 	"encoding/xml"


### PR DESCRIPTION
- Package renamed exosx
- Made the client's SessionKey public
- Changed to use environment variables for configurable test parameters
- Updated depreciated NewGomegaWithT() call
- Added support for two hash functions
- Updated license to Apache 2.0, saved off old LICENSE

TODO:
- Correct tests to work with both older and newer APIs
- Integrate semantic versioning with github

-----
[View rendered README.md](https://github.com/Seagate/seagate-exos-x-api-go/blob/feat/rebrand/README.md)