### PR TITLE
feat/rebrand

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 #
 # Local testing parameters - replace <variables> with correct values, do not commit!
 #
-STORAGEIP=http:<ipaddress>
+TEST_STORAGEIP=http:<ipaddress>
 TEST_USERNAME=<username>
 TEST_PASSWORD=<password>

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This option runs the Go language test cases against a live storage system. Two s
 - Run `go test -v`
 
 Another option is to define environment variables, which take precedence over .env values
-- export TEST_STORAGEIP=http:/<ipaddress>
+- export TEST_STORAGEIP=http://<ipaddress>
 - export TEST_USERNAME=<username>
-- export TEST_USERNAME=<password>
+- export TEST_PASSWORD=<password>
 - Run `go test -v`
 - unset TEST_STORAGEIP TEST_PASSWORD TEST_USERNAME
 

--- a/main_test.go
+++ b/main_test.go
@@ -79,8 +79,8 @@ func TestReLoginFailed(t *testing.T) {
 	_, status, err := wrongClient.Request("/status/code/1")
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
-	// This test returns one of two different values based on the  API version, either: 'request failed' or 'Invalid sessionkey'
-	g.Expect(status.Response).Should(BeElementOf([]string{"request failed", "Invalid sessionkey"}))
+	// This test returns one of three different values based on the  API version.
+	g.Expect(status.Response).Should(BeElementOf([]string{"re-login failed", "request failed", "Invalid sessionkey"}))
 }
 
 func TestInvalidURL(t *testing.T) {


### PR DESCRIPTION
Corrected three mistakes with the naming of env variables and the associated comments.

-----
[View rendered README.md](https://github.com/Seagate/seagate-exos-x-api-go/blob/feat/rebrand/README.md)