### PR TITLE
Feat/apitest2

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,5 @@
 TEST_STORAGEIP=http:<ipaddress>
 TEST_USERNAME=<username>
 TEST_PASSWORD=<password>
+TEST_INITIATOR=<host-initiator>
+TEST_POOL=<pool>

--- a/README.md
+++ b/README.md
@@ -12,12 +12,22 @@ This option runs the Go language test cases against a live storage system. Two s
 - Run `go test -v`
 
 Another option is to define environment variables, which take precedence over .env values
-- export TEST_STORAGEIP=http://<ipaddress>
-- export TEST_USERNAME=<username>
-- export TEST_PASSWORD=<password>
+- export TEST_STORAGEIP=http://[ipaddress]
+- export TEST_USERNAME=[username]
+- export TEST_PASSWORD=[password]
+- export TEST_INITIATOR=[initiator]
+- export TEST_POOL=[pool]
 - Run `go test -v`
-- unset TEST_STORAGEIP TEST_PASSWORD TEST_USERNAME
+- unset TEST_STORAGEIP TEST_PASSWORD TEST_USERNAME TEST_INITIATOR TEST_POOL
 
+To just validate all API calls against a specified target
+- export TEST_STORAGEIP=http://[ipaddress]
+- export TEST_USERNAME=[username]
+- export TEST_PASSWORD=[password]
+- export TEST_INITIATOR=[initiator]
+- export TEST_POOL=[pool]
+- Run `go test -v -run TestAPI`
+- unset TEST_STORAGEIP TEST_PASSWORD TEST_USERNAME TEST_INITIATOR TEST_POOL
 
 ## Test Using a Mock Server
 

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,466 @@
+//
+// Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// For any questions about this software or licensing,
+// please email opensource@seagate.com or cortx-questions@seagate.com.
+
+package exosx
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+	"k8s.io/klog"
+)
+
+//
+// An API Test Suite
+//
+// Goal: Execute every possible Storage Array API call used by the CSI Driver so
+//       those calls are validated against all supported storage array API versions.
+//
+// API Calls Tested:
+//     /login
+//     /show/versions/detail
+//     /show/controllers
+//     /show/pools
+//     /create/volume
+//     /show/volumes
+//     /show/initiators/
+//     /show/maps
+//     /show/maps/initiators/
+//     /map/volume
+//     /expand/volume
+//     /copy/volume
+//     /show/snapshots
+//     /create/snapshots
+//     /delete/snapshot
+//     /unmap/volume
+//     /delete/volumes
+//     /set/initiator - called if an initiator nickname is needed
+//
+
+var size = "1GiB"
+var volname1 = "apitest_1"
+var volname2 = "apitest_2"
+var expandSize = "1GiB"
+var snap1 = "snap1"
+var snap2 = "snap2"
+var loginFail = false
+
+func ShowVolume(t *testing.T, volumeName string) {
+	g := NewWithT(t)
+
+	response, status, err := client.ShowVolumes(volumeName)
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	volume := response.ObjectsMap["volume"]
+	bint, _ := strconv.ParseInt(volume.PropertiesMap["blocks"].Data, 10, 64)
+	bsint, _ := strconv.ParseInt(volume.PropertiesMap["blocksize"].Data, 10, 64)
+
+	p := message.NewPrinter(language.English)
+	p.Printf("\n")
+	p.Printf("    volume-name       = %v\n", volume.PropertiesMap["volume-name"].Data)
+	p.Printf("    storage-pool-name = %v\n", volume.PropertiesMap["storage-pool-name"].Data)
+	p.Printf("    blocksize         = %v\n", bsint)
+	p.Printf("    blocks            = %d\n", bint)
+	p.Printf("    current size      = %d\n", bsint*bint)
+	p.Printf("    tier-affinity     = %v\n", volume.PropertiesMap["tier-affinity"].Data)
+	p.Printf("\n")
+}
+
+func ShowVolumes(t *testing.T) {
+	g := NewWithT(t)
+
+	response, status, err := client.ShowVolumes()
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	if err == nil {
+		fmt.Printf("\n")
+		fmt.Printf("Volumes:\n")
+		for _, object := range response.Objects {
+			if object.Name == "volume" {
+				blocks, _ := strconv.ParseInt(object.PropertiesMap["blocks"].Data, 10, 64)
+				blocksize, _ := strconv.ParseInt(object.PropertiesMap["blocksize"].Data, 10, 64)
+
+				fmt.Printf("%8v, %32v, %10v, %8v, %10v, %v, %8v, %v\n",
+					object.PropertiesMap["storage-pool-name"].Data,
+					object.PropertiesMap["volume-name"].Data,
+					object.PropertiesMap["total-size"].Data,
+					blocks,
+					blocksize,
+					object.PropertiesMap["storage-type"].Data,
+					object.PropertiesMap["volume-type"].Data,
+					object.PropertiesMap["health"].Data,
+				)
+			}
+		}
+	}
+
+	fmt.Printf("\n")
+}
+
+func ShowSnapshots(t *testing.T, names string) {
+	g := NewWithT(t)
+
+	var err error
+	var status *ResponseStatus
+	var response *Response
+	response, status, err = client.ShowSnapshots(names)
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	if err == nil {
+		for _, obj := range response.Objects {
+			fmt.Printf("++ obj.Name = %v\n", obj.Name)
+		}
+	}
+
+	fmt.Printf("\n")
+}
+
+func ConditionalSkip(t *testing.T) {
+	if loginFail {
+		t.Skip()
+	}
+}
+func TestAPILogin(t *testing.T) {
+	g := NewWithT(t)
+	err := client.Login()
+	if err != nil {
+		loginFail = true
+	}
+	g.Expect(err).To(BeNil())
+}
+
+func TestAPIVersions(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	response, status, err := client.FormattedRequest("/show/versions/detail")
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	fmt.Printf("\n")
+	fmt.Printf("                  Controller A Versions        Controller B Versions\n")
+	fmt.Printf("                  ---------------------        ---------------------\n")
+
+	var mccodea, mcbasea, mccodeb, mcbaseb string
+
+	if err == nil {
+		for _, obj := range response.Objects {
+			if obj.Name == "controller-a-versions" {
+				mccodea = obj.PropertiesMap["mc-fw"].Data
+				mcbasea = obj.PropertiesMap["mc-base-fw"].Data
+			}
+			if obj.Name == "controller-b-versions" {
+				mccodeb = obj.PropertiesMap["mc-fw"].Data
+				mcbaseb = obj.PropertiesMap["mc-base-fw"].Data
+			}
+		}
+	}
+
+	fmt.Printf("MC Code Version:  %-28v %v\n", mccodea, mccodeb)
+	fmt.Printf("MC Base Version:  %-28v %v\n", mcbasea, mcbaseb)
+	fmt.Printf("\n")
+}
+
+func TestAPIControllers(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	respone, status, err := client.FormattedRequest("/show/controllers")
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	if err == nil {
+		for _, obj1 := range respone.Objects {
+			if obj1.Name == "controller" || obj1.Name == "controllers" {
+				fmt.Printf("\n")
+				fmt.Printf("Controller     = %v\n", obj1.PropertiesMap["controller-id"].Data)
+				fmt.Printf("Disks          = %v\n", obj1.PropertiesMap["disks"].Data)
+				fmt.Printf("IP Address     = %v\n", obj1.PropertiesMap["ip-address"].Data)
+				fmt.Printf("Model          = %v\n", obj1.PropertiesMap["model"].Data)
+				fmt.Printf("Platform       = %v\n", obj1.PropertiesMap["platform-type"].Data)
+				fmt.Printf("Serial Number  = %v\n", obj1.PropertiesMap["serial-number"].Data)
+				fmt.Printf("Status         = %v\n", obj1.PropertiesMap["status"].Data)
+				fmt.Printf("Storage Pools  = %v\n", obj1.PropertiesMap["number-of-storage-pools"].Data)
+				fmt.Printf("Disk Groups    = %v\n", obj1.PropertiesMap["virtual-disks"].Data)
+
+				for _, obj2 := range obj1.Objects {
+					if obj2.Name == "ports" {
+						fmt.Printf("-- Port        = %v, %v, %v",
+							obj2.PropertiesMap["port"].Data,
+							obj2.PropertiesMap["port-type"].Data,
+							obj2.PropertiesMap["target-id"].Data,
+						)
+						if obj2.PropertiesMap["port-type"].Data == "iSCSI" {
+							for _, obj3 := range obj2.Objects {
+								// fmt.Printf("obj3=%+v\n", obj3)
+								// fmt.Printf("obj3.Name=%v\n", obj3.Name)
+								if obj3.Name == "port-details" {
+									fmt.Printf(", %15v, %12v, %v",
+										obj3.PropertiesMap["ip-address"].Data,
+										obj3.PropertiesMap["sfp-present"].Data,
+										obj3.PropertiesMap["sfp-ethernet-compliance"].Data,
+									)
+								}
+							}
+						}
+						fmt.Printf("\n")
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Printf("\n")
+}
+
+func TestAPIInitSystem(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+	err := client.InitSystem(client.PoolName)
+	g.Expect(err).To(BeNil())
+}
+
+func TestAPICreateVolume(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	var err error
+	var status *ResponseStatus
+	_, status, err = client.CreateVolume(volname1, size, client.PoolName, client.PoolData.Type)
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	ShowVolume(t, volname1)
+	ShowVolumes(t)
+}
+
+func TestAPIShowInitiators(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	respone, status, err := client.FormattedRequest("/show/initiators/")
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	fmt.Printf("\n")
+	fmt.Printf("Nickname        Discovered Mapped Profile  Host Type  ID\n")
+
+	if err == nil {
+		for _, obj := range respone.Objects {
+			if obj.Name == "initiator" {
+				fmt.Printf("%-16s", obj.PropertiesMap["nickname"].Data)
+				fmt.Printf("%-11s", obj.PropertiesMap["discovered"].Data)
+				fmt.Printf("%-7s", obj.PropertiesMap["mapped"].Data)
+				fmt.Printf("%-9s", obj.PropertiesMap["profile"].Data)
+				fmt.Printf("%-11s", obj.PropertiesMap["host-bus-type"].Data)
+				fmt.Printf("%s", obj.PropertiesMap["id"].Data)
+				fmt.Printf("\n")
+			}
+		}
+	}
+
+	fmt.Printf("\n")
+}
+
+func TestAPIGetMaps(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	respone, status, err := client.FormattedRequest("/show/maps/%s", volname1)
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	hostNames := []string{}
+
+	if err == nil {
+		for _, rootObj := range respone.Objects {
+			if rootObj.Name != "volume-view" {
+				continue
+			}
+
+			for _, object := range rootObj.Objects {
+				hostName := object.PropertiesMap["identifier"].Data
+				if object.Name == "host-view" && hostName != "all other initiators" {
+					hostNames = append(hostNames, hostName)
+				}
+			}
+		}
+	}
+
+	fmt.Printf("volume %q host names:\n", volname1)
+	for i, h := range hostNames {
+		fmt.Printf("    [%d] %s\n", i, h)
+	}
+}
+
+func TestAPIMapVolume(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+	lun, err := client.PublishVolume(volname1, client.Initiator)
+	g.Expect(err).To(BeNil())
+	g.Expect(lun).ToNot(Equal(0))
+}
+
+func TestAPIExpandVolume(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	klog.Infof("expand volume (%s) from original size (%s) to new size (%s)", volname1, size, expandSize)
+	_, status, err := client.ExpandVolume(volname1, expandSize)
+	if err != nil {
+		if status != nil && status.ReturnCode != 0 {
+			fmt.Printf("expand volume failed, status.ReturnCode=%v", status.ReturnCode)
+		}
+	}
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	klog.Infof("successfully expanded volume (%s)", volname1)
+	ShowVolume(t, volname1)
+}
+
+func TestAPICreateSnapshots(t *testing.T) {
+	ConditionalSkip(t)
+
+	if client.PoolData.Type == "Linear" {
+		fmt.Printf("Linear snapshots are not supported\n")
+		return
+	}
+
+	g := NewWithT(t)
+
+	klog.Infof("snapshot volume (%s) using name (%s)", volname1, snap1)
+	_, status, err := client.CreateSnapshot(volname1, snap1)
+	if err != nil {
+		if status != nil && status.ReturnCode != 0 {
+			fmt.Printf("snapshot volume failed, status.ReturnCode=%v", status.ReturnCode)
+		}
+	}
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	klog.Infof("successfully snapped volume (%s)", snap1)
+	ShowVolumes(t)
+
+	klog.Infof("snapshot volume (%s) using name (%s)", volname1, snap2)
+	_, status, err = client.CreateSnapshot(volname1, snap2)
+	if err != nil {
+		if status != nil && status.ReturnCode != 0 {
+			fmt.Printf("snapshot volume failed, status.ReturnCode=%v", status.ReturnCode)
+		}
+	}
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	klog.Infof("successfully snapped volume (%s)", snap2)
+	ShowVolumes(t)
+}
+
+func TestAPIDeleteSnapshots(t *testing.T) {
+	ConditionalSkip(t)
+
+	if client.PoolData.Type == "Linear" {
+		fmt.Printf("Linear snapshots are not supported\n")
+		return
+	}
+
+	g := NewWithT(t)
+
+	klog.Infof("delete snapshot (%s)", snap1)
+	_, status, err := client.DeleteSnapshot(snap1)
+	if err != nil {
+		if status != nil && status.ReturnCode != 0 {
+			fmt.Printf("delete snapshot failed, status.ReturnCode=%v", status.ReturnCode)
+		}
+	}
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	klog.Infof("successfully deleted snapshot (%s)", snap1)
+
+	klog.Infof("delete snapshot (%s)", snap2)
+	_, status, err = client.DeleteSnapshot(snap2)
+	if err != nil {
+		if status != nil && status.ReturnCode != 0 {
+			fmt.Printf("delete snapshot failed, status.ReturnCode=%v", status.ReturnCode)
+		}
+	}
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	klog.Infof("successfully deleted snapshot (%s)", snap2)
+	ShowVolumes(t)
+}
+
+func TestAPIUnmapVolume(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	klog.Infof("unmapping volume %s from initiator %s", volname1, client.Initiator)
+	_, status, err := client.UnmapVolume(volname1, client.Initiator)
+	if err != nil {
+		if status != nil && status.ReturnCode == unmapFailedErrorCode {
+			fmt.Printf("unmap failed, assuming volume is already unmapped")
+		}
+	}
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	klog.Infof("successfully unmapped volume %s from initiator %s", volname1, client.Initiator)
+}
+
+func TestAPICopyVolume(t *testing.T) {
+	ConditionalSkip(t)
+
+	if client.PoolData.Type == "Linear" {
+		fmt.Printf("Linear snapshots are not supported\n")
+		return
+	}
+
+	g := NewWithT(t)
+
+	klog.Infof("copy volume (%s) to (%s) using pool (%s)", volname1, volname1, client.PoolName)
+
+	_, status, err := client.CopyVolume(volname1, volname2, client.PoolName)
+	if err != nil {
+		if status != nil && status.ReturnCode != 0 {
+			fmt.Printf("copy volume failed, status.ReturnCode=%v", status.ReturnCode)
+		}
+	}
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	klog.Infof("successfully copied volume to (%s)", volname2)
+	ShowVolumes(t)
+}
+
+func TestAPIDeleteVolumes(t *testing.T) {
+	ConditionalSkip(t)
+	g := NewWithT(t)
+
+	_, status, err := client.DeleteVolume(volname1)
+	g.Expect(err).To(BeNil())
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+
+	if client.PoolData.Type != "Linear" {
+		_, status, err := client.DeleteVolume(volname2)
+		g.Expect(err).To(BeNil())
+		g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	}
+
+	ShowVolumes(t)
+}

--- a/endpoints.go
+++ b/endpoints.go
@@ -53,23 +53,26 @@ func (client *Client) CreateNickname(name, iqn string) (*Response, *ResponseStat
 	return client.FormattedRequest("/set/initiator/id/\"%s\"/nickname/\"%s\"", iqn, name)
 }
 
-// MapVolume : map a volume to host + LUN
-func (client *Client) MapVolume(name, host, access string, lun int) (*Response, *ResponseStatus, error) {
-	return client.FormattedRequest("/map/volume/access/%s/lun/%d/initiator/%s/\"%s\"", access, lun, host, name)
+// MapVolume : map a volume to an initiator using a specified LUN
+func (client *Client) MapVolume(name, initiator, access string, lun int) (*Response, *ResponseStatus, error) {
+	return client.FormattedRequest("/map/volume/access/%s/lun/%d/initiator/\"%s\"/\"%s\"", access, lun, initiator, name)
 }
 
 // ShowVolumes : get informations about volumes
 func (client *Client) ShowVolumes(volumes ...string) (*Response, *ResponseStatus, error) {
+	if len(volumes) == 0 {
+		return client.FormattedRequest("/show/volumes/")
+	}
 	return client.FormattedRequest("/show/volumes/\"%s\"", strings.Join(volumes, ","))
 }
 
-// UnmapVolume : unmap a volume from host
-func (client *Client) UnmapVolume(name, host string) (*Response, *ResponseStatus, error) {
-	if host == "" {
+// UnmapVolume : unmap a volume from an initiator
+func (client *Client) UnmapVolume(name, initiator string) (*Response, *ResponseStatus, error) {
+	if len(initiator) == 0 {
 		return client.FormattedRequest("/unmap/volume/\"%s\"", name)
 	}
 
-	return client.FormattedRequest("/unmap/volume/initiator/\"%s\"/\"%s\"", host, name)
+	return client.FormattedRequest("/unmap/volume/initiator/\"%s\"/\"%s\"", initiator, name)
 }
 
 // ExpandVolume : extend a volume if there is enough space on the vdisk
@@ -84,7 +87,7 @@ func (client *Client) DeleteVolume(name string) (*Response, *ResponseStatus, err
 
 // DeleteHost : deletes a host by its ID or nickname
 func (client *Client) DeleteHost(name string) (*Response, *ResponseStatus, error) {
-	return client.FormattedRequest("/delete/host/\"%s\"", name)
+	return client.FormattedRequest("/delete/hosts/\"%s\"", name)
 }
 
 // ShowHostMaps : list the volume mappings for given host

--- a/exosx.go
+++ b/exosx.go
@@ -11,14 +11,25 @@ import (
 	"k8s.io/klog"
 )
 
+// Pool: Linear or virtual pool attributes
+type Pool struct {
+	Name         string
+	SerialNumber string
+	Type         string
+}
+
 // Client : Can be used to request the API
 type Client struct {
-	Username   string
-	Password   string
-	Addr       string
-	HTTPClient http.Client
-	Collector  *Collector
-	SessionKey string
+	SystemInitialized bool
+	Username          string
+	Password          string
+	Addr              string
+	HTTPClient        http.Client
+	Collector         *Collector
+	SessionKey        string
+	Initiator         string
+	PoolName          string
+	PoolData          Pool
 }
 
 // NewClient : Creates an API client by setting up its HTTP transport

--- a/exosx.go
+++ b/exosx.go
@@ -11,25 +11,17 @@ import (
 	"k8s.io/klog"
 )
 
-// Pool: Linear or virtual pool attributes
-type Pool struct {
-	Name         string
-	SerialNumber string
-	Type         string
-}
-
 // Client : Can be used to request the API
 type Client struct {
-	SystemInitialized bool
-	Username          string
-	Password          string
-	Addr              string
-	HTTPClient        http.Client
-	Collector         *Collector
-	SessionKey        string
-	Initiator         string
-	PoolName          string
-	PoolData          Pool
+	Username   string
+	Password   string
+	Addr       string
+	HTTPClient http.Client
+	Collector  *Collector
+	SessionKey string
+	Initiator  string
+	PoolName   string
+	Info       *SystemInfo
 }
 
 // NewClient : Creates an API client by setting up its HTTP transport

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.10.5
 	github.com/prometheus/client_golang v1.10.0
+	golang.org/x/text v0.3.3
+	google.golang.org/grpc v1.26.0
 	k8s.io/klog v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
+google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -389,6 +390,7 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/main_test.go
+++ b/main_test.go
@@ -50,6 +50,16 @@ func init() {
 	if exists {
 		fmt.Printf("Testing setup: %s=%s\n", "TEST_PASSWORD", client.Password)
 	}
+
+	client.Initiator, exists = os.LookupEnv("TEST_INITIATOR")
+	if exists {
+		fmt.Printf("Testing setup: %s=%s\n", "TEST_INITIATOR", client.Initiator)
+	}
+
+	client.PoolName, exists = os.LookupEnv("TEST_POOL")
+	if exists {
+		fmt.Printf("Testing setup: %s=%s\n", "TEST_POOL", client.PoolName)
+	}
 }
 
 func assert(t *testing.T, cond bool, msg string) {

--- a/request.go
+++ b/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // Request : Used internally, and can be used to send custom requests (see Client.Request())
@@ -13,6 +14,10 @@ type Request struct {
 }
 
 func (req *Request) execute(client *Client) ([]byte, int, error) {
+	// Remove any trailing slash if supplied, other login fails with HTTP status 403
+	if strings.HasSuffix(client.Addr, "/") {
+		client.Addr = client.Addr[0 : len(client.Addr)-1]
+	}
 	url := fmt.Sprintf("%s/api%s", client.Addr, req.Endpoint)
 	httpReq, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/system.go
+++ b/system.go
@@ -1,0 +1,235 @@
+//
+// Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// For any questions about this software or licensing,
+// please email opensource@seagate.com or cortx-questions@seagate.com.
+
+package exosx
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+//
+// System Information Storage and Creation
+//
+
+// PoolType: Linear or virtual pool attributes
+type PoolType struct {
+	Name         string
+	SerialNumber string
+	Type         string
+}
+
+// PortType: Storage system port attributes
+type PortType struct {
+	Label      string
+	Type       string
+	TargetId   string
+	IPAddress  string
+	Present    string
+	Compliance string
+}
+
+// System: Information stored for a storage array controller
+type SystemInfo struct {
+	IPAddress     string
+	HTTP          string
+	URL           string
+	Controller    string
+	Platform      string
+	SerialNumber  string
+	Status        string
+	MCCodeVersion string
+	MCBaseVersion string
+	Pools         []PoolType
+	Ports         []PortType
+}
+
+// SystemsData: Information stored multiple storage array controllers
+type SystemsData struct {
+	Systems []*SystemInfo
+}
+
+// systems: Data object storing all system information for all added controllers
+var systems SystemsData
+
+// AddSystem: Uses the client to query and store system data
+func AddSystem(url string, client *Client) error {
+
+	// Create the system record with the designated ip address
+	var s SystemInfo
+	s.URL = strings.ToLower(url)
+	if strings.HasPrefix(s.URL, "http://") {
+		parts := strings.Split(s.URL, "http://")
+		if len(parts) >= 2 {
+			s.HTTP = "http://"
+			s.IPAddress = parts[1]
+		}
+	} else if strings.HasPrefix(s.URL, "https://") {
+		parts := strings.Split(s.URL, "https://")
+		if len(parts) >= 2 {
+			s.HTTP = "https://"
+			s.IPAddress = parts[1]
+		}
+	} else {
+		s.IPAddress = s.URL
+		s.HTTP = "http://"
+	}
+	systems.Systems = append(systems.Systems, &s)
+	s.Ports = nil
+
+	// Extract and store controller data, including ports
+	response, status, err := client.FormattedRequest("/show/controllers")
+	if err == nil && status.ResponseTypeNumeric == 0 {
+		for _, obj1 := range response.Objects {
+			if obj1.Name == "controller" || obj1.Name == "controllers" {
+				klog.V(2).Infof("++ Processing controller (%s)\n", obj1.PropertiesMap["controller-id"].Data)
+
+				if obj1.PropertiesMap["ip-address"].Data == s.IPAddress {
+					klog.V(2).Infof("++ Saving controller (%s)\n", obj1.PropertiesMap["controller-id"].Data)
+					s.Controller = obj1.PropertiesMap["controller-id"].Data
+					s.Platform = obj1.PropertiesMap["platform-type"].Data
+					s.SerialNumber = obj1.PropertiesMap["serial-number"].Data
+					s.Status = obj1.PropertiesMap["status"].Data
+				}
+
+				for _, obj2 := range obj1.Objects {
+					if obj2.Name == "ports" {
+						klog.V(2).Infof("++ Adding port (%s)\n", obj2.PropertiesMap["port"].Data)
+						p := PortType{
+							Label:    obj2.PropertiesMap["port"].Data,
+							Type:     obj2.PropertiesMap["port-type"].Data,
+							TargetId: obj2.PropertiesMap["target-id"].Data,
+						}
+						if obj2.PropertiesMap["port-type"].Data == "iSCSI" {
+							for _, obj3 := range obj2.Objects {
+								if obj3.Name == "port-details" {
+									p.IPAddress = obj3.PropertiesMap["ip-address"].Data
+									p.Present = obj3.PropertiesMap["sfp-present"].Data
+									p.Compliance = obj3.PropertiesMap["sfp-ethernet-compliance"].Data
+								}
+							}
+						}
+						s.Ports = append(s.Ports, p)
+					}
+				}
+			}
+		}
+	}
+
+	// Extract and store controller firmware versions
+	response, status, err = client.FormattedRequest("/show/versions/detail")
+	if err == nil && status.ResponseTypeNumeric == 0 {
+		for _, obj1 := range response.Objects {
+			if strings.EqualFold("A", s.Controller) && obj1.Name == "controller-a-versions" {
+				s.MCCodeVersion = obj1.PropertiesMap["mc-fw"].Data
+				s.MCBaseVersion = obj1.PropertiesMap["mc-base-fw"].Data
+			}
+			if strings.EqualFold("B", s.Controller) && obj1.Name == "controller-b-versions" {
+				s.MCCodeVersion = obj1.PropertiesMap["mc-fw"].Data
+				s.MCBaseVersion = obj1.PropertiesMap["mc-base-fw"].Data
+			}
+		}
+	}
+
+	// Extract and store pool data
+	s.Pools = nil
+	response, status, err = client.FormattedRequest("/show/pools")
+	if err == nil && status.ResponseTypeNumeric == 0 {
+		for _, obj1 := range response.Objects {
+			if obj1.Name == "pools" || obj1.Name == "pool" {
+				klog.V(2).Infof("++ Adding pool (%s)\n", obj1.PropertiesMap["name"].Data)
+				s.Pools = append(s.Pools,
+					PoolType{
+						Name:         obj1.PropertiesMap["name"].Data,
+						SerialNumber: obj1.PropertiesMap["serial-number"].Data,
+						Type:         obj1.PropertiesMap["storage-type"].Data,
+					})
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetSystem: Return the System data object correspoinding to the IP Address
+func GetSystem(url string) (*SystemInfo, error) {
+
+	for _, s := range systems.Systems {
+		if s.URL == url {
+			return s, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no system data found for ip (%s) in (%d) systems", url, len(systems.Systems))
+}
+
+//
+// System functions for ease of use
+//
+
+// Log: Display the contents of all system information collected
+func (system *SystemInfo) Log() error {
+
+	klog.Infof("\n")
+	klog.Infof("System Infomration:")
+
+	klog.Infof("\n")
+	klog.Infof("=== Controller ===")
+	klog.Infof("IPAddress:     %v\n", system.IPAddress)
+	klog.Infof("HTTP:          %v\n", system.HTTP)
+	klog.Infof("Controller:    %v\n", system.Controller)
+	klog.Infof("Platform:      %v\n", system.Platform)
+	klog.Infof("SerialNumber:  %v\n", system.SerialNumber)
+	klog.Infof("Status:        %v\n", system.Status)
+	klog.Infof("MCCodeVersion: %v\n", system.MCCodeVersion)
+	klog.Infof("MCBaseVersion: %v\n", system.MCBaseVersion)
+
+	klog.Infof("\n")
+	klog.Infof("=== Ports ===")
+	for i, p := range system.Ports {
+		klog.Infof("Port [%d] %v, %v, %v, %15v, %12v, %v\n",
+			i, p.Label, p.Type, p.TargetId, p.IPAddress, p.Present, p.Compliance)
+	}
+
+	klog.Infof("\n")
+	klog.Infof("=== Pools ===")
+	for i, p := range system.Pools {
+		klog.Infof("Pool [%d] %-12s  %-8s  %s\n", i, p.Name, p.Type, p.SerialNumber)
+	}
+
+	klog.Infof("\n")
+	return nil
+}
+
+// GetPoolType: Return the pool type for a given pool
+func (system *SystemInfo) GetPoolType(pool string) (string, error) {
+	if system == nil {
+		return "", fmt.Errorf("system pointer was nil")
+	}
+
+	for _, p := range system.Pools {
+		if p.Name == pool {
+			klog.V(2).Infof("++ pool (%s) type is (%s)\n", p.Name, p.Type)
+			return p.Type, nil
+		}
+	}
+
+	return "", fmt.Errorf("pool (%s) was not found in (%d) system information pools", pool, len(system.Pools))
+}


### PR DESCRIPTION
- Version 0.5.1
- Added test functions for all storage api commands used by the driver
- Removed "poolType" from StorageClass parameters, this is retrieved from the controller
- New client.InitSystemInfo() which is called once to retrieve required storage system info
- Sets the stage for removing iqn and portals from StorageClass, since the data is now discovered


-----
[View rendered README.md](https://github.com/Seagate/seagate-exos-x-api-go/blob/feat/apitest2/README.md)