### PR TITLE
fix: ShowSnapshots() now takes two parameters, snapshot and source volume id

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -130,7 +130,7 @@ func ShowSnapshot(t *testing.T, name string) {
 	var err error
 	var status *ResponseStatus
 	var response *Response
-	response, status, err = client.ShowSnapshots(name)
+	response, status, err = client.ShowSnapshots(name, "")
 	g.Expect(err).To(BeNil())
 	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
 

--- a/endpoints.go
+++ b/endpoints.go
@@ -121,12 +121,14 @@ func (client *Client) ShowHostMaps(host string) ([]Volume, *ResponseStatus, erro
 	return mappings, status, err
 }
 
-// ShowSnapshots : Show one snaphot, or all snapshots if name = ""
-func (client *Client) ShowSnapshots(names ...string) (*Response, *ResponseStatus, error) {
-	if len(names) == 0 {
-		return client.FormattedRequest("/show/snapshots")
+// ShowSnapshots : Show one snaphot, or all snapshots, or all snapshots for a volume
+func (client *Client) ShowSnapshots(snapshotId string, sourceVolumeId string) (*Response, *ResponseStatus, error) {
+	if sourceVolumeId != "" {
+		return client.FormattedRequest("/show/snapshots/volume/%q", sourceVolumeId)
+	} else if snapshotId != "" {
+		return client.FormattedRequest("/show/snapshots/pattern/%q", snapshotId)
 	}
-	return client.FormattedRequest("/show/snapshots/pattern/%q", strings.Join(names, ","))
+	return client.FormattedRequest("/show/snapshots")
 }
 
 // CreateSnapshot : create a snapshot in a snap pool and the snap pool if it doesn't exsits


### PR DESCRIPTION
This update was made to properly handle CSI Driver Spec ListSnapshots calls discovered during csi-sanity testing.
The caller can now list all snapshots, list all snapshots matching a snapshot id, or all snapshots for a source volume id.