### PR TITLE
fix: CheckVolumeExists() optimization and new GetVolumeWwn()

### DIFF
--- a/api.go
+++ b/api.go
@@ -448,14 +448,10 @@ func (client *Client) PublishVolume(volumeId string, initiatorName string) (stri
 func (client *Client) GetVolumeWwn(volumeName string) (string, error) {
 
 	wwn := ""
-	response, _, err := client.ShowVolumes(volumeName)
-	if err == nil {
-		statusObject := response.ObjectsMap["status"]
-		if statusObject != nil {
-			responseTypeNumeric, _ := strconv.Atoi(statusObject.PropertiesMap["response-type-numeric"].Data)
-			if responseTypeNumeric == 0 {
-				wwn = strings.ToLower(response.ObjectsMap["volume"].PropertiesMap["wwn"].Data)
-			}
+	response, status, err := client.ShowVolumes(volumeName)
+	if err == nil && status.ResponseTypeNumeric == 0 {
+		if response.ObjectsMap["volume"] != nil {
+			wwn = strings.ToLower(response.ObjectsMap["volume"].PropertiesMap["wwn"].Data)
 		}
 	}
 


### PR DESCRIPTION
- Optimization to CheckVolumeExists() to show one volume, which produces an error log entry, but that is used to indicate that the volume does not exist
- Added GetVolumeWwn() to execute a storage controller command to retrieve the WWN. This results in a slight addition of execution time, but provides the ability to locate operating system devices based on WWN rather than IP Address and LUN.