### PR TITLE
fix: ChooseLUN uses next highest lun before wrapping

### DIFF
--- a/api.go
+++ b/api.go
@@ -330,6 +330,11 @@ func (client *Client) chooseLUN(initiatorName string) (int, error) {
 
 	sort.Sort(Volumes(volumes))
 
+	klog.V(5).Infof("checking if next LUN is not above maximum LUNs limit")
+	if volumes[len(volumes)-1].LUN+1 < MaximumLUN {
+		return volumes[len(volumes)-1].LUN + 1, nil
+	}
+
 	klog.V(5).Infof("checking if LUN 1 is not already in use")
 	if len(volumes) == 0 || volumes[0].LUN > 1 {
 		return 1, nil
@@ -342,10 +347,7 @@ func (client *Client) chooseLUN(initiatorName string) (int, error) {
 		}
 	}
 
-	klog.V(5).Infof("checking if next LUN is not above maximum LUNs limit")
-	if volumes[len(volumes)-1].LUN+1 < MaximumLUN {
-		return volumes[len(volumes)-1].LUN + 1, nil
-	}
+	klog.Errorf("no more available LUNs: [%d] luns=%v", len(volumes), volumes)
 
 	return -1, status.Error(codes.ResourceExhausted, "no more available LUNs")
 }

--- a/api.go
+++ b/api.go
@@ -330,24 +330,30 @@ func (client *Client) chooseLUN(initiatorName string) (int, error) {
 
 	sort.Sort(Volumes(volumes))
 
-	klog.V(5).Infof("checking if next LUN is not above maximum LUNs limit")
+	klog.V(5).Infof("use LUN 1 when volumes slice is empty")
+	if len(volumes) == 0 {
+		return 1, nil
+	}
+
+	klog.V(5).Infof("use the next highest LUN number, until the end is reached")
 	if volumes[len(volumes)-1].LUN+1 < MaximumLUN {
 		return volumes[len(volumes)-1].LUN + 1, nil
 	}
 
-	klog.V(5).Infof("checking if LUN 1 is not already in use")
-	if len(volumes) == 0 || volumes[0].LUN > 1 {
+	klog.V(5).Infof("use LUN 1 when not in use")
+	if volumes[0].LUN > 1 {
 		return 1, nil
 	}
 
-	klog.V(5).Infof("searching for an available LUN between LUNs in use")
+	klog.V(5).Infof("use the next available LUN, searching from LUN 1 towards the maximum")
 	for index := 1; index < len(volumes); index++ {
+		// Find a gap between used LUNs
 		if volumes[index].LUN-volumes[index-1].LUN > 1 {
 			return volumes[index-1].LUN + 1, nil
 		}
 	}
 
-	klog.Errorf("no more available LUNs: [%d] luns=%v", len(volumes), volumes)
+	klog.Errorf("no available LUN: [%d] luns=%v", len(volumes), volumes)
 
 	return -1, status.Error(codes.ResourceExhausted, "no more available LUNs")
 }


### PR DESCRIPTION
Change ChooseLUN to pick the next highest available lun before wrapping. This avoids an issue where the lun is reused and the determine multipath code in the iscsi lib get confused because the file system is very busy trying to catch up with all the new devices. This allows the pvc-hell stress test to pass but will need to research an alternate approach such as using WWN.