### PR TITLE
fix(ShowHostMaps): Return host maps when initiator has a nickname or …

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -93,17 +93,23 @@ func (client *Client) DeleteHost(name string) (*Response, *ResponseStatus, error
 // ShowHostMaps : list the volume mappings for given host
 // If host is an empty string, mapping for all hosts is shown
 func (client *Client) ShowHostMaps(host string) ([]Volume, *ResponseStatus, error) {
-	if len(host) > 0 {
-		host = fmt.Sprintf("\"%s\"", host)
-	}
+	// We don't use "/show/maps/initiator/<host>" here because
+	// the maps for an initiator with a nickname or in a host group will not
+	// be returned. Instead we get all initiator mappings and filter by initiator
 	klog.Infof("++ ShowHostMaps(%v)", host)
-	res, status, err := client.FormattedRequest("/show/maps/initiator/%s", host)
+	res, status, err := client.FormattedRequest("/show/maps/initiator/")
 	if err != nil {
 		return nil, status, err
 	}
 
 	mappings := make([]Volume, 0)
 	for _, rootObj := range res.Objects {
+		if host != "" {
+			id, err := rootObj.GetProperties("id")
+			if err != nil || id[0].Data != host {
+				continue
+			}
+		}
 		if rootObj.Name != "initiator-view" {
 			continue
 		}


### PR DESCRIPTION
…is in a group

Previous implementation using 'show maps initiator <initiatorName>' api would not return mappings if the initiator requested has a nickname. Instead return all mappings from the api and then filter that list for the given initiator.