### PR TITLE
chore: add workflow_dispatch to enable manual workflow run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    tags:
+      description: 'Allow manual releases'
   push:
     branches:
       - main
-  workflow_dispatch: release.yml
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: release.yml
 
 jobs:
 


### PR DESCRIPTION
Add a new workflow_dispatch to the release.yml to enable the manually running of the release workflow.