### PR TITLE
chore: remove release.yml changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    tags:
-      description: 'Allow manual releases'
   push:
     branches:
       - main


### PR DESCRIPTION
Remove the release.yml changes that result in an error, even though the GitHub documents this as the way to allow manual workflow execution.