### PR TITLE
fix: use 'snapshot' instead of 'snapshots' for object.Name

### DIFF
--- a/pkg/regression/v1_snapshots.go
+++ b/pkg/regression/v1_snapshots.go
@@ -44,6 +44,7 @@ var _ = DescribeRegression("Snapshot Testing (v1)", func(tc *TestContext) {
 			response, status, err := client.ShowVolumes(volname1)
 			Expect(err).To(BeNil())
 			Expect(status.ResponseTypeNumeric).To(Equal(0))
+			Expect(len(response)).To(Equal(1))
 			ShowVolumes(logger, response)
 		})
 
@@ -60,6 +61,8 @@ var _ = DescribeRegression("Snapshot Testing (v1)", func(tc *TestContext) {
 			snapshots, status, err := client.ShowSnapshots(snap1, "")
 			Expect(err).To(BeNil())
 			Expect(status.ResponseTypeNumeric).To(Equal(0))
+			Expect(len(snapshots)).To(Equal(1))
+			Expect(snapshots[0].Name).To(Equal(snap1))
 			ShowSnapshots(logger, snapshots)
 
 			// Show volumes
@@ -79,10 +82,12 @@ var _ = DescribeRegression("Snapshot Testing (v1)", func(tc *TestContext) {
 			Expect(status.ResponseTypeNumeric).To(Equal(0))
 
 			// Show snapshots
-			snapshots, status, err := client.ShowSnapshots(snap1, "")
+			snapshots, status, err := client.ShowSnapshots(snap2, "")
 			Expect(err).To(BeNil())
 			Expect(status.ResponseTypeNumeric).To(Equal(0))
 			ShowSnapshots(logger, snapshots)
+			Expect(len(snapshots)).To(Equal(1))
+			Expect(snapshots[0].Name).To(Equal(snap2))
 
 			// Show volumes
 			volumes, status, err := client.ShowVolumes(volname1)

--- a/pkg/regression/v2_snapshots.go
+++ b/pkg/regression/v2_snapshots.go
@@ -44,6 +44,7 @@ var _ = DescribeRegression("Snapshot Testing (v2)", func(tc *TestContext) {
 			response, status, err := client.ShowVolumes(volname1)
 			Expect(err).To(BeNil())
 			Expect(status.ResponseTypeNumeric).To(Equal(storageapi.ApiSuccess))
+			Expect(len(response)).To(Equal(1))
 			ShowVolumes(logger, response)
 		})
 
@@ -60,6 +61,8 @@ var _ = DescribeRegression("Snapshot Testing (v2)", func(tc *TestContext) {
 			snapshots, status, err := client.ShowSnapshots(snap1, "")
 			Expect(err).To(BeNil())
 			Expect(status.ResponseTypeNumeric).To(Equal(storageapi.ApiSuccess))
+			Expect(len(snapshots)).To(Equal(1))
+			Expect(snapshots[0].Name).To(Equal(snap1))
 			ShowSnapshots(logger, snapshots)
 
 			// Show volumes
@@ -79,10 +82,12 @@ var _ = DescribeRegression("Snapshot Testing (v2)", func(tc *TestContext) {
 			Expect(status.ResponseTypeNumeric).To(Equal(storageapi.ApiSuccess))
 
 			// Show snapshots
-			snapshots, status, err := client.ShowSnapshots(snap1, "")
+			snapshots, status, err := client.ShowSnapshots(snap2, "")
 			Expect(err).To(BeNil())
 			Expect(status.ResponseTypeNumeric).To(Equal(storageapi.ApiSuccess))
 			ShowSnapshots(logger, snapshots)
+			Expect(len(snapshots)).To(Equal(1))
+			Expect(snapshots[0].Name).To(Equal(snap2))
 
 			// Show volumes
 			volumes, status, err := client.ShowVolumes(volname1)

--- a/pkg/v1/endpoints.go
+++ b/pkg/v1/endpoints.go
@@ -285,7 +285,7 @@ func (client *Client) ShowSnapshots(snapshotId string, sourceVolumeId string) ([
 	// Fill in Snapshot properties for all data objects returned
 	if err == nil && status.ResponseTypeNumeric == 0 {
 		for _, object := range data.Objects {
-			if object.Name == "snapshots" {
+			if object.Name == "snapshot" {
 				snapshot := common.SnapshotObject{}
 				snapshot.ObjectName = object.Name
 				snapshot.CreationTime, _ = common.CreationTimeFromString(object.PropertiesMap["creation-date-time-numeric"].Data)


### PR DESCRIPTION
Fix typo when parsing api output into snapshot struct