### PR TITLE
Updates to the V2 library to fix CSI sanity test cases

### DIFF
--- a/pkg/api/mcapi.go
+++ b/pkg/api/mcapi.go
@@ -62,10 +62,7 @@ func (client *Client) StoreCredentials(addr string, protocol string, username st
 
 // Login: Called to log into the storage controller API
 func (client *Client) Login(ctx context.Context) error {
-
-	if client.Ctx == nil {
-		client.Ctx = ctx
-	}
+	client.Ctx = ctx
 
 	config := &common.Config{
 		MCIpAddress: client.Addr,
@@ -86,7 +83,9 @@ func (client *Client) Login(ctx context.Context) error {
 
 // SessionValid : Determine if a session is valid, if not a login is required
 func (client *Client) SessionValid(addr, username string) bool {
-
+	if client.Ctx == nil {
+		return false
+	}
 	logger := klog.FromContext(client.Ctx)
 
 	// addr may include protocol and ip address or hostname, or only ip address

--- a/pkg/api/system.go
+++ b/pkg/api/system.go
@@ -169,6 +169,11 @@ func Log(system *common.SystemInfo) error {
 	return nil
 }
 
+// GetPoolType: Return the pool type of the storage system
+func (client *Client) GetPoolType(pool string) (string, error) {
+	return GetPoolType(client.Info, pool)
+}
+
 // GetPoolType: Return the pool type for a given pool
 func GetPoolType(system *common.SystemInfo, pool string) (string, error) {
 	if system == nil {

--- a/pkg/common/mc.go
+++ b/pkg/common/mc.go
@@ -70,10 +70,6 @@ func GetAddressAndProtocol(addr string, protocol string) (string, string) {
 // Login: Perform the needed steps to configure a connection and login to the MC
 func Login(ctx context.Context, config *Config) (*client.APIClient, error) {
 
-	if apiClient != nil {
-		return apiClient, nil
-	}
-
 	logger := klog.FromContext(ctx)
 
 	configuration := &client.Configuration{

--- a/pkg/common/response.go
+++ b/pkg/common/response.go
@@ -3,11 +3,10 @@
 package common
 
 import (
-	"strconv"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Exos X Storage API Error Codes
@@ -64,10 +63,10 @@ type SnapshotObject struct {
 }
 
 func CreationTimeFromString(creationTime string) (*timestamp.Timestamp, error) {
-	creationTimestamp, err := strconv.ParseInt(creationTime, 10, 64)
+	creationTimestamp, err := time.Parse(time.DateTime, creationTime)
 	if err != nil {
 		return nil, err
 	}
 
-	return ptypes.TimestampProto(time.Unix(creationTimestamp, 0))
+	return timestamppb.New(creationTimestamp), nil
 }


### PR DESCRIPTION
This PR resolves several CSI driver sanity test suite failures when building the driver against version 2.0.2 by updating 2 areas of code; Login functions and snapshot timestamp parsing. It also restores the Client.GetPoolType convenience method for code clarity.

1. client.Login and common.Login: Remove checks for previously defined client objects, to allow users to force a new Login if necessary, for example if a session has expired and needs to be re-initialized.
2. Update the parsing of snapshot creation time. Previously this code expected a timestamp as an integer in seconds, but this version of the API was passing in a formatted date time string e.g. "2006-01-02 15:04:05". This caused the CreationTime timestamp field to be set to nil. 
3. The GetPoolType function is most often used with Client.Info as the first parameter. The Client.GetPoolType method allows this to be called more simply as client.GetPoolType(<pool name>).
