### PR TITLE
fix: Create volume without tier-affinity for linear

### DIFF
--- a/api/mc-openapi.yaml
+++ b/api/mc-openapi.yaml
@@ -519,6 +519,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/statusObject'
   # /create/volume
+  /create/volume/pool/{poolOption}/size/{sizeOption}/{nameOption}:
+    get:
+      description: Execute /create/volume command
+      operationId: CreateVolumePoolSizeNameGet
+      parameters:
+        - $ref: '#/components/parameters/poolOption'
+        - $ref: '#/components/parameters/sizeOption'
+        - $ref: '#/components/parameters/nameOption'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/volumesObject'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusObject'
+  # /create/volume
   /create/volume/pool/{poolOption}/size/{sizeOption}/tier-affinity/{tier-affinityOption}/{nameOption}:
     get:
       description: Execute /create/volume command
@@ -819,6 +841,12 @@ components:
       required: true
       schema:
         type: string
+    nameOption:
+      name: nameOption
+      in: path
+      required: true
+      schema:
+        type: string
     tier-affinityOption:
       name: tier-affinityOption
       in: path
@@ -829,12 +857,6 @@ components:
         - 'no-affinity'
         - 'archive'
         - 'performance'
-    nameOption:
-      name: nameOption
-      in: path
-      required: true
-      schema:
-        type: string
     volumesOption:
       name: volumesOption
       in: path

--- a/internal/generator/mc-commands.yaml
+++ b/internal/generator/mc-commands.yaml
@@ -237,9 +237,29 @@ commands:
       type: string
       keyword-required: true
       description: size size[B|KB|MB|GB|TB|KiB|MiB|GiB|TiB]. Sets the volume size. The unit is optional (B represents bytes). If base 2 is in use, whether you specify a base-2 or base-10 unit, the resulting size will be in base 2. If no unit is specified, the default is 512-byte blocks
+    - flag: name
+      type: string
+      required: true
+      keyword-required: false
+      description: A name for the new volume. The name must be unique system-wide. Input rules are case sensitive, maximum of 32 bytes, printable UTF-8 characters but " , < \, use double quotes when name has spaces
+
+  - command: /create/volume
+    meta: volumes
+    include:
+    - status
+    options:
+    - flag: pool
+      type: string
+      keyword-required: true
+      description: Optional for linear volumes. Required for virtual volumes. The name or serial number of the pool in which to create the volume
+    - flag: size
+      type: string
+      keyword-required: true
+      description: size size[B|KB|MB|GB|TB|KiB|MiB|GiB|TiB]. Sets the volume size. The unit is optional (B represents bytes). If base 2 is in use, whether you specify a base-2 or base-10 unit, the resulting size will be in base 2. If no unit is specified, the default is 512-byte blocks
     - flag: tier-affinity
       type: enum
       values: no-affinity,archive,performance
+      required: true
       keyword-required: true
       description: For virtual storage, this specifies how to tune the tier-migration algorithm for the volume
     - flag: name

--- a/pkg/api/volumes.go
+++ b/pkg/api/volumes.go
@@ -315,7 +315,7 @@ func (client *Client) chooseLUN(initiators []string) (int, error) {
 	return -1, status.Error(codes.ResourceExhausted, "no more available LUNs")
 }
 
-// MapVolume : map a volume to an inidftiator using a specified LUN
+// MapVolume : map a volume to an initiator using a specified LUN
 func (client *Client) MapVolume(name, initiator, access string, lun int) (*common.ResponseStatus, error) {
 
 	logger := klog.FromContext(client.Ctx)

--- a/pkg/api/volumes.go
+++ b/pkg/api/volumes.go
@@ -61,11 +61,11 @@ func UpdateVolumeObject(target *common.VolumeObject, source *client.VolumesResou
 }
 
 // CreateVolume : creates a volume with the given name, capacity in the given pool
-func (myclient *Client) CreateVolume(name, size, pool string) (*common.VolumeObject, *common.ResponseStatus, error) {
+func (client *Client) CreateVolume(name, size, pool string) (*common.VolumeObject, *common.ResponseStatus, error) {
 
-	logger := klog.FromContext(myclient.Ctx)
-	response, httpRes, err := myclient.apiClient.DefaultApi.CreateVolumePoolSizeNameGet(myclient.Ctx, pool, size, name).Execute()
-	logger.V(2).Info("create volume", "name", name, "http", httpRes.Status, "response", response)
+	logger := klog.FromContext(client.Ctx)
+	response, httpRes, err := client.apiClient.DefaultApi.CreateVolumePoolSizeNameGet(client.Ctx, pool, size, name).Execute()
+	logger.V(4).Info("create volume", "name", name, "http", httpRes.Status, "response", response)
 
 	status := &common.ResponseStatus{}
 	if response != nil && len(response.GetStatus()) > 0 {
@@ -79,7 +79,7 @@ func (myclient *Client) CreateVolume(name, size, pool string) (*common.VolumeObj
 
 	// For API versions that do not return a representation of the volume object, use ShowVolumes to fill in the data
 	if err == nil && status.ResponseTypeNumeric == 0 && volume.Wwn == "" {
-		volumes, status, err := myclient.ShowVolumes(name)
+		volumes, status, err := client.ShowVolumes(name)
 		if err == nil && status.ResponseTypeNumeric == 0 {
 			if len(volumes) > 0 && volumes[0].ObjectName == "volume" {
 				volume = common.VolumeObject(volumes[0])
@@ -315,7 +315,7 @@ func (client *Client) chooseLUN(initiators []string) (int, error) {
 	return -1, status.Error(codes.ResourceExhausted, "no more available LUNs")
 }
 
-// MapVolume : map a volume to an initiator using a specified LUN
+// MapVolume : map a volume to an inidftiator using a specified LUN
 func (client *Client) MapVolume(name, initiator, access string, lun int) (*common.ResponseStatus, error) {
 
 	logger := klog.FromContext(client.Ctx)

--- a/pkg/api/volumes.go
+++ b/pkg/api/volumes.go
@@ -61,19 +61,10 @@ func UpdateVolumeObject(target *common.VolumeObject, source *client.VolumesResou
 }
 
 // CreateVolume : creates a volume with the given name, capacity in the given pool
-func (myclient *Client) CreateVolume(name, size, pool, poolType string) (*common.VolumeObject, *common.ResponseStatus, error) {
+func (myclient *Client) CreateVolume(name, size, pool string) (*common.VolumeObject, *common.ResponseStatus, error) {
 
 	logger := klog.FromContext(myclient.Ctx)
-
-	var response *client.VolumesObject
-	var httpRes *http.Response
-	var err error
-	if poolType == "Linear" {
-		response, httpRes, err = myclient.apiClient.DefaultApi.CreateVolumePoolSizeNameGet(myclient.Ctx, pool, size, name).Execute()
-	} else if poolType == "Virtual" {
-		response, httpRes, err = myclient.apiClient.DefaultApi.CreateVolumePoolSizeTierAffinityNameGet(myclient.Ctx, pool, size, ApiTierAffinity, name).Execute()
-	}
-
+	response, httpRes, err := myclient.apiClient.DefaultApi.CreateVolumePoolSizeNameGet(myclient.Ctx, pool, size, name).Execute()
 	logger.V(2).Info("create volume", "name", name, "http", httpRes.Status, "response", response)
 
 	status := &common.ResponseStatus{}

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -80,6 +80,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *DefaultApi* | [**CopyVolumeDestinationPoolNameSourceGet**](docs/DefaultApi.md#copyvolumedestinationpoolnamesourceget) | **Get** /copy/volume/destination-pool/{destination-poolOption}/name/{nameOption}/{sourceOption} | 
 *DefaultApi* | [**CreateSnapshotsVolumesNamesGet**](docs/DefaultApi.md#createsnapshotsvolumesnamesget) | **Get** /create/snapshots/volumes/{volumesOption}/{namesOption} | 
+*DefaultApi* | [**CreateVolumePoolSizeNameGet**](docs/DefaultApi.md#createvolumepoolsizenameget) | **Get** /create/volume/pool/{poolOption}/size/{sizeOption}/{nameOption} | 
 *DefaultApi* | [**CreateVolumePoolSizeTierAffinityNameGet**](docs/DefaultApi.md#createvolumepoolsizetieraffinitynameget) | **Get** /create/volume/pool/{poolOption}/size/{sizeOption}/tier-affinity/{tier-affinityOption}/{nameOption} | 
 *DefaultApi* | [**DeleteHostsNamesGet**](docs/DefaultApi.md#deletehostsnamesget) | **Get** /delete/hosts/{namesOption} | 
 *DefaultApi* | [**DeleteInitiatorNicknameNameGet**](docs/DefaultApi.md#deleteinitiatornicknamenameget) | **Get** /delete/initiator-nickname/{nameOption} | 

--- a/pkg/client/api/openapi.yaml
+++ b/pkg/client/api/openapi.yaml
@@ -533,6 +533,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/statusObject'
           description: Unauthorized
+  /create/volume/pool/{poolOption}/size/{sizeOption}/{nameOption}:
+    get:
+      description: Execute /create/volume command
+      operationId: CreateVolumePoolSizeNameGet
+      parameters:
+      - explode: false
+        in: path
+        name: poolOption
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: sizeOption
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: nameOption
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/volumesObject'
+          description: OK
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusObject'
+          description: Unauthorized
   /create/volume/pool/{poolOption}/size/{sizeOption}/tier-affinity/{tier-affinityOption}/{nameOption}:
     get:
       description: Execute /create/volume command
@@ -973,6 +1012,14 @@ components:
       schema:
         type: string
       style: simple
+    nameOption:
+      explode: false
+      in: path
+      name: nameOption
+      required: true
+      schema:
+        type: string
+      style: simple
     tier-affinityOption:
       explode: false
       in: path
@@ -983,14 +1030,6 @@ components:
         - no-affinity
         - archive
         - performance
-        type: string
-      style: simple
-    nameOption:
-      explode: false
-      in: path
-      name: nameOption
-      required: true
-      schema:
         type: string
       style: simple
     volumesOption:
@@ -65902,9 +65941,9 @@ components:
           return-code: 6
       properties:
         status:
-        initiator-view:
+          items:
             $ref: '#/components/schemas/statusResource_inner'
-            $ref: '#/components/schemas/initiator_viewResource_inner'
+          maxItems: 1024
           minItems: 1
           type: array
         initiator-view:
@@ -82587,7 +82626,7 @@ components:
     host_view_mappingsResource_inner:
       example:
         access: access
-        access-numeric: 0
+        access-numeric: 6
         lun: lun
         object-name: object-name
         meta: meta

--- a/pkg/client/api_default.go
+++ b/pkg/client/api_default.go
@@ -262,6 +262,128 @@ func (a *DefaultApiService) CreateSnapshotsVolumesNamesGetExecute(r ApiCreateSna
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type ApiCreateVolumePoolSizeNameGetRequest struct {
+	ctx        context.Context
+	ApiService *DefaultApiService
+	poolOption string
+	sizeOption string
+	nameOption string
+}
+
+func (r ApiCreateVolumePoolSizeNameGetRequest) Execute() (*VolumesObject, *http.Response, error) {
+	return r.ApiService.CreateVolumePoolSizeNameGetExecute(r)
+}
+
+/*
+CreateVolumePoolSizeNameGet Method for CreateVolumePoolSizeNameGet
+
+Execute /create/volume command
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param poolOption
+	@param sizeOption
+	@param nameOption
+	@return ApiCreateVolumePoolSizeNameGetRequest
+*/
+func (a *DefaultApiService) CreateVolumePoolSizeNameGet(ctx context.Context, poolOption string, sizeOption string, nameOption string) ApiCreateVolumePoolSizeNameGetRequest {
+	return ApiCreateVolumePoolSizeNameGetRequest{
+		ApiService: a,
+		ctx:        ctx,
+		poolOption: poolOption,
+		sizeOption: sizeOption,
+		nameOption: nameOption,
+	}
+}
+
+// Execute executes the request
+//
+//	@return VolumesObject
+func (a *DefaultApiService) CreateVolumePoolSizeNameGetExecute(r ApiCreateVolumePoolSizeNameGetRequest) (*VolumesObject, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodGet
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *VolumesObject
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.CreateVolumePoolSizeNameGet")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/create/volume/pool/{poolOption}/size/{sizeOption}/{nameOption}"
+	localVarPath = strings.Replace(localVarPath, "{"+"poolOption"+"}", url.PathEscape(parameterValueToString(r.poolOption, "poolOption")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"sizeOption"+"}", url.PathEscape(parameterValueToString(r.sizeOption, "sizeOption")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"nameOption"+"}", url.PathEscape(parameterValueToString(r.nameOption, "nameOption")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v StatusObject
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type ApiCreateVolumePoolSizeTierAffinityNameGetRequest struct {
 	ctx                context.Context
 	ApiService         *DefaultApiService

--- a/pkg/client/docs/DefaultApi.md
+++ b/pkg/client/docs/DefaultApi.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**CopyVolumeDestinationPoolNameSourceGet**](DefaultApi.md#CopyVolumeDestinationPoolNameSourceGet) | **Get** /copy/volume/destination-pool/{destination-poolOption}/name/{nameOption}/{sourceOption} | 
 [**CreateSnapshotsVolumesNamesGet**](DefaultApi.md#CreateSnapshotsVolumesNamesGet) | **Get** /create/snapshots/volumes/{volumesOption}/{namesOption} | 
+[**CreateVolumePoolSizeNameGet**](DefaultApi.md#CreateVolumePoolSizeNameGet) | **Get** /create/volume/pool/{poolOption}/size/{sizeOption}/{nameOption} | 
 [**CreateVolumePoolSizeTierAffinityNameGet**](DefaultApi.md#CreateVolumePoolSizeTierAffinityNameGet) | **Get** /create/volume/pool/{poolOption}/size/{sizeOption}/tier-affinity/{tier-affinityOption}/{nameOption} | 
 [**DeleteHostsNamesGet**](DefaultApi.md#DeleteHostsNamesGet) | **Get** /delete/hosts/{namesOption} | 
 [**DeleteInitiatorNicknameNameGet**](DefaultApi.md#DeleteInitiatorNicknameNameGet) | **Get** /delete/initiator-nickname/{nameOption} | 
@@ -181,6 +182,82 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**StatusObject**](StatusObject.md)
+
+### Authorization
+
+[basicAuth](../README.md#basicAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## CreateVolumePoolSizeNameGet
+
+> VolumesObject CreateVolumePoolSizeNameGet(ctx, poolOption, sizeOption, nameOption).Execute()
+
+
+
+
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID"
+)
+
+func main() {
+    poolOption := "poolOption_example" // string | 
+    sizeOption := "sizeOption_example" // string | 
+    nameOption := "nameOption_example" // string | 
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.DefaultApi.CreateVolumePoolSizeNameGet(context.Background(), poolOption, sizeOption, nameOption).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.CreateVolumePoolSizeNameGet``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+    // response from `CreateVolumePoolSizeNameGet`: VolumesObject
+    fmt.Fprintf(os.Stdout, "Response from `DefaultApi.CreateVolumePoolSizeNameGet`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**poolOption** | **string** |  | 
+**sizeOption** | **string** |  | 
+**nameOption** | **string** |  | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateVolumePoolSizeNameGetRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+
+
+### Return type
+
+[**VolumesObject**](VolumesObject.md)
 
 ### Authorization
 

--- a/pkg/client/test/api_default_test.go
+++ b/pkg/client/test/api_default_test.go
@@ -53,6 +53,22 @@ func Test_client_DefaultApiService(t *testing.T) {
 
 	})
 
+	t.Run("Test DefaultApiService CreateVolumePoolSizeNameGet", func(t *testing.T) {
+
+		t.Skip("skip test") // remove to run test
+
+		var poolOption string
+		var sizeOption string
+		var nameOption string
+
+		resp, httpRes, err := apiClient.DefaultApi.CreateVolumePoolSizeNameGet(context.Background(), poolOption, sizeOption, nameOption).Execute()
+
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, 200, httpRes.StatusCode)
+
+	})
+
 	t.Run("Test DefaultApiService CreateVolumePoolSizeTierAffinityNameGet", func(t *testing.T) {
 
 		t.Skip("skip test") // remove to run test

--- a/pkg/regression/v2_snapshots.go
+++ b/pkg/regression/v2_snapshots.go
@@ -14,7 +14,6 @@ var _ = DescribeRegression("Snapshot Testing (v2)", func(tc *TestContext) {
 		client   *storageapi.Client = nil
 		volname1                    = "apitest_1"
 		size                        = "1GiB"
-		poolType                    = "Virtual"
 		snap1                       = "snap1"
 		snap2                       = "snap2"
 	)
@@ -26,6 +25,7 @@ var _ = DescribeRegression("Snapshot Testing (v2)", func(tc *TestContext) {
 		client = storageapi.NewClient()
 		client.StoreCredentials(tc.Config.StorageController.Ip, tc.Config.StorageController.Protocol, tc.Config.StorageController.Username, tc.Config.StorageController.Password)
 		err := client.Login(tc.Config.Ctx)
+		client.InitSystemInfo()
 		logger.V(3).Info("Login", "ipaddress", client.Addr, "username", client.Username, "err", err)
 		Expect(err).To(BeNil())
 	})
@@ -34,7 +34,7 @@ var _ = DescribeRegression("Snapshot Testing (v2)", func(tc *TestContext) {
 		It("should successfully create the volume", func() {
 
 			logger := klog.FromContext(tc.Config.Ctx)
-			volume, status, err := client.CreateVolume(volname1, size, tc.Config.StorageController.Pool, poolType)
+			volume, status, err := client.CreateVolume(volname1, size, tc.Config.StorageController.Pool)
 			logger.V(3).Info("CreateVolume", "name", volname1, "size", size, "wwn", volume.Wwn, "mc-response", status.ResponseTypeNumeric)
 
 			Expect(err).To(BeNil())

--- a/pkg/regression/v2_volumes.go
+++ b/pkg/regression/v2_volumes.go
@@ -17,7 +17,6 @@ var _ = DescribeRegression("Volume Testing (v2)", func(tc *TestContext) {
 		volname2                       = "apitest_2"
 		size                           = "1GiB"
 		expandSize                     = "1GiB"
-		poolType                       = "Virtual"
 		sizeValue   int64              = 1024 * 1024 * 1024
 	)
 
@@ -30,13 +29,15 @@ var _ = DescribeRegression("Volume Testing (v2)", func(tc *TestContext) {
 		err := client.Login(tc.Config.Ctx)
 		logger.V(3).Info("Login", "ipaddress", client.Addr, "username", client.Username, "err", err)
 		Expect(err).To(BeNil())
+		err = client.InitSystemInfo()
+		Expect(err).To(BeNil())
 	})
 
 	Describe("v2VolumeTest", func() {
 		It("should successfully create the volume", func() {
 
 			logger := klog.FromContext(tc.Config.Ctx)
-			volume, status, err := client.CreateVolume(volname1, size, tc.Config.StorageController.Pool, poolType)
+			volume, status, err := client.CreateVolume(volname1, size, tc.Config.StorageController.Pool)
 			logger.V(3).Info("CreateVolume", "name", volname1, "size", size, "wwn", volume.Wwn, "mc-response", status.ResponseTypeNumeric)
 
 			Expect(err).To(BeNil())
@@ -89,7 +90,7 @@ var _ = DescribeRegression("Volume Testing (v2)", func(tc *TestContext) {
 		It("should successfully create a second volume", func() {
 
 			logger := klog.FromContext(tc.Config.Ctx)
-			volume, status, err := client.CreateVolume(volname2, size, tc.Config.StorageController.Pool, poolType)
+			volume, status, err := client.CreateVolume(volname2, size, tc.Config.StorageController.Pool)
 			logger.V(3).Info("CreateVolume", "name", volname2, "size", size, "wwn", volume.Wwn, "mc-response", status.ResponseTypeNumeric)
 
 			Expect(err).To(BeNil())


### PR DESCRIPTION
Add a second version of the CreateVolume call without tier-affinity as the tier-affinity parameter may be considered an invalid parameter on linear pools. Use this new api call in the higher level CreateVolume function when creating volumes on linear type pools.