### PR TITLE
feat: Controller failover for API calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ REGRESSION_APP := api-regression
 GENERATOR_VERSION := v6.5.0
 
 # For docker, set uid and gid to match the current user
-GENERATE_USER_ARGS := -u $(shell id -u ${USER}):$(shell id -g ${USER})
+#GENERATE_USER_ARGS := -u $(shell id -u ${USER}):$(shell id -g ${USER})
 # For podman, do not set this value
-#GENERATE_USER_ARGS:=
+GENERATE_USER_ARGS:=
 
 help:
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Use the `./api-regression -config <filename>` option to specify your configurati
 # api-regression configuration
 #
 # Properties:
-#   'ip' is required and is the IP Address of the storage controller used for testing
+#   'mc-ip-addrs:' is required and is the IP Addresses of the storage controller(s) used for testing. At least one address must be specified
 #   'protocol" specifies http or https
 #   'username' is required and is the login credentials for the storage controller
 #   'password' is required and is the login credentials for the storage controller
@@ -393,7 +393,7 @@ Use the `./api-regression -config <filename>` option to specify your configurati
 api-regression: 1.0.0
 
 # Example Controller
-ip: "<ipaddress>"
+mc-ip-addrs: ["<ipaddress-a>", "<ipaddress-b>"]
 protocol: "https"
 username: "<username>"
 password: "<password>"

--- a/pkg/api/mcapi.go
+++ b/pkg/api/mcapi.go
@@ -17,18 +17,20 @@ import (
 
 // Client : Can be used to request the API
 type Client struct {
-	Ctx        context.Context
-	Username   string
-	Password   string
-	Addr       string
-	Protocol   string
-	HTTPClient http.Client
-	Collector  *common.Collector
-	SessionKey string
-	Initiator  []string
-	PoolName   string
-	Info       *common.SystemInfo
-	apiClient  *client.APIClient
+	Ctx           context.Context
+	Username      string
+	Password      string
+	Addrs         []string
+	CurrentAddr   string
+	NotResponding string
+	Protocol      string
+	HTTPClient    http.Client
+	Collector     *common.Collector
+	SessionKey    string
+	Initiator     []string
+	PoolName      string
+	Info          *common.SystemInfo
+	apiClient     *client.APIClient
 }
 
 // NewClient : Creates an API client by setting up its HTTP transport
@@ -48,87 +50,130 @@ func NewClient() *Client {
 }
 
 // StoreCredentials : Called to store ip address, username, and password for the client
-func (client *Client) StoreCredentials(addr string, protocol string, username string, password string) {
-
+func (client *Client) StoreCredentials(addrs []string, protocol string, username string, password string) {
 	// addr may include protocol and ip address or hostname, or only ip address
-	ipaddress, usingProtocol := common.GetAddressAndProtocol(addr, protocol)
+	ipaddress, usingProtocol := common.GetAddressAndProtocol(addrs[0], protocol)
 
 	// Store the login credentials in the Client object
 	client.Username = username
 	client.Password = password
-	client.Addr = ipaddress
+	client.CurrentAddr = ipaddress
 	client.Protocol = usingProtocol
+	client.Addrs = addrs
+}
+
+func (client *Client) MarkCurrentControllerDown() error {
+	if len(client.Addrs) < 2 {
+		return fmt.Errorf("cannot mark controller down with less than 2 controller IP addresses configured")
+	}
+	downController := client.CurrentAddr
+	for _, addr := range client.Addrs {
+		if addr != downController {
+			client.Addrs[0] = addr
+			client.Addrs[1] = downController
+			break
+		}
+	}
+	return nil
 }
 
 // Login: Called to log into the storage controller API
-func (client *Client) Login(ctx context.Context) error {
-	client.Ctx = ctx
+func (myclient *Client) Login(ctx context.Context) (err error) {
+	logger := klog.FromContext(ctx)
 
-	config := &common.Config{
-		MCIpAddress: client.Addr,
-		MCProtocol:  client.Protocol,
-		MCUsername:  client.Username,
-		MCPassword:  client.Password,
+	var api_client *client.APIClient
+	myclient.SessionKey = ""
+
+	for _, host := range myclient.Addrs {
+		myclient.CurrentAddr, _ = common.GetAddressAndProtocol(host, myclient.Protocol)
+		config := &common.Config{
+			MCIpAddress: myclient.CurrentAddr,
+			MCProtocol:  myclient.Protocol,
+			MCUsername:  myclient.Username,
+			MCPassword:  myclient.Password,
+		}
+
+		myclient.Ctx = context.WithValue(ctx, client.ContextBasicAuth, client.BasicAuth{
+			UserName: myclient.Username,
+			Password: myclient.Password,
+		})
+		logger.V(4).Info("==============config=================", "config", config)
+		api_client, err = common.Login(myclient.Ctx, config)
+
+		if err == nil && api_client != nil {
+			myclient.apiClient = api_client
+			configuration := api_client.GetConfig()
+			myclient.SessionKey = configuration.DefaultHeader["sessionKey"]
+		}
+		// if we have a new session key, login was successful and we can leave
+		// if not, try the next controller IP
+		if myclient.SessionKey != "" {
+			break
+		}
 	}
-
-	apiClient, err := common.Login(ctx, config)
-	if err == nil && apiClient != nil {
-		client.apiClient = apiClient
-		configuration := apiClient.GetConfig()
-		client.SessionKey = configuration.DefaultHeader["sessionKey"]
-	}
-
 	return err
 }
 
-// Login: Called to log into the storage controller API
+// Logout: Called to log out of the storage controller API
 func (client *Client) Logout() error {
 	if client.Ctx == nil {
 		client.Ctx = context.Background()
 	}
 	_, _, err := client.apiClient.DefaultApi.LogoutGet(client.Ctx).Execute()
+	if err == nil {
+		client.SessionKey = ""
+	}
 	return err
-}
-
-// SessionValid : Determine if a session is valid, if not a login is required
-// Makes the 'show controller-date' API call to validate the session is still valid
-//
-// Deprecated: This function will be made redundant by retry logic in a future update
-func (client *Client) SessionValid(addr, username string) bool {
-	if client.Ctx == nil {
-		return false
-	}
-	logger := klog.FromContext(client.Ctx)
-
-	// addr may include protocol and ip address or hostname, or only ip address
-	ipaddress := common.GetAddress(addr)
-
-	if client.Addr == ipaddress && client.Username == username {
-		if client.SessionKey == "" {
-			logger.V(2).Info("session invalid", "sessionkey", client.SessionKey)
-			return false
-		}
-	}
-
-	//run an API call to test that the session is still valid
-	_, _, err := client.apiClient.DefaultApi.ShowControllerDateGet(client.Ctx).Execute()
-	return err == nil
 }
 
 // InitSystemInfo: Retrieve and store system information for this client
 func (client *Client) InitSystemInfo() error {
 
-	err := AddSystem(client.Addr, client)
+	err := AddSystem(client.CurrentAddr, client)
 	if err != nil {
-		return fmt.Errorf("unable to add system info for ip (%s) ", client.Addr)
+		return fmt.Errorf("unable to add system info for ip (%s) ", client.CurrentAddr)
 	}
 
-	client.Info, err = GetSystem(client.Addr)
+	client.Info, err = GetSystem(client.CurrentAddr)
 	if err == nil {
 		_ = Log(client.Info)
 	}
 
 	return err
+}
+
+type ResponseType interface {
+	GetStatus() []client.StatusResourceInner
+}
+
+// ExecuteWithFailover: Retry wrapper for the Execute functions of the openapi generated client library
+// If the initial request fails, attempts to login on the secondary controller
+func ExecuteWithFailover[R ResponseType](executeFunc func() (R, *http.Response, error), client *Client) (R, *common.ResponseStatus, *http.Response, error) {
+	logger := klog.FromContext(client.Ctx)
+	logger.V(4).Info("Execute with retry...")
+	response, httpRes, err := executeFunc()
+	if err == nil {
+		status := response.GetStatus()
+		commonStatus := CreateCommonStatus(logger, &status)
+		return response, commonStatus, httpRes, err
+	}
+	if len(client.Addrs) > 1 {
+		client.NotResponding = client.CurrentAddr
+		logger.V(1).Info("Retrying...", "err", err, "response", response)
+		client.MarkCurrentControllerDown()
+		client.Login(client.Ctx)
+		response, httpRes, err = executeFunc()
+		if err != nil {
+			return response, nil, httpRes, err
+		} else {
+			status := response.GetStatus()
+			commonStatus := CreateCommonStatus(logger, &status)
+			return response, commonStatus, httpRes, err
+		}
+	} else {
+		logger.V(1).Info("Cannot failover as only 1 controller address Specified")
+		return response, nil, httpRes, err
+	}
 }
 
 // CreateCommonStatus : create a common API status object based on the OpenAPI client response
@@ -164,6 +209,7 @@ func CreateCommonStatus(logger logr.Logger, response *[]client.StatusResourceInn
 					"ResponseType", *s.ResponseType,
 					"ResponseTypeNumeric", *s.ResponseTypeNumeric,
 					"Response", *s.Response,
+					"ResponseCode", s.GetReturnCode(),
 				)
 				found = true
 				status.ResponseType = s.GetResponseType()

--- a/pkg/api/mcapi.go
+++ b/pkg/api/mcapi.go
@@ -97,7 +97,7 @@ func (myclient *Client) Login(ctx context.Context) (err error) {
 			UserName: myclient.Username,
 			Password: myclient.Password,
 		})
-		logger.V(4).Info("==============config=================", "config", config)
+		logger.V(4).Info("==============config=================", "IPAddr", config.MCIpAddress, "Username", config.MCUsername)
 		api_client, err = common.Login(myclient.Ctx, config)
 
 		if err == nil && api_client != nil {

--- a/pkg/common/mc.go
+++ b/pkg/common/mc.go
@@ -107,10 +107,10 @@ func Login(ctx context.Context, config *Config) (*client.APIClient, error) {
 			return nil, fmt.Errorf("++ MC Login FAILURE, response=%v", *resp1.Status[0].Response)
 		}
 	} else {
-		logger.V(2).Info("-- LoginGet", "httpRes", httpRes, "err", err)
+		logger.V(3).Info("-- LoginGet", "httpRes", httpRes, "err", err)
 		return nil, fmt.Errorf("++ MC Login FAILURE, err=%v", err)
 	}
-	logger.V(3).Info("================================================================================")
+	logger.Info("================================================================================")
 
 	// Store the 'sessionKey' in the default header
 	configuration.DefaultHeader["sessionKey"] = sessionKey

--- a/pkg/common/response.go
+++ b/pkg/common/response.go
@@ -18,6 +18,7 @@ const (
 	InvalidArgumentErrorCode              = -10058
 	HostMapDoesNotExistsErrorCode         = -10074
 	VolumeNotFoundErrorCode               = -10075
+	UserNotRecognized                     = -10027
 	VolumeHasSnapshot                     = -10183
 	SnapshotAlreadyExists                 = -10186
 	InitiatorNicknameOrIdentifierNotFound = -10386

--- a/pkg/common/response.go
+++ b/pkg/common/response.go
@@ -25,6 +25,23 @@ const (
 	UnmapFailedErrorCode                  = -10509
 )
 
+var RetryableErrorCodes = []int{
+	2193, //"Communications error with the Storage Controller (code version mismatch between MC and SC).",
+	2194, //"Communications error with the Storage Controller (timeout).",
+	2195, //"Communications error with the Storage Controller.",
+	3046, //"No resources are available to complete the request.",
+	3047, //"The controller is not in the correct shutdown state.",
+	3060, //"Controller internal error.",
+	3108, //"Controller not online.",
+	3115, //"Timeout communicating to other controller.",
+	3122, //"Controller communication failed.",
+	1019, // "The Storage Controller has been shut down. The current operation is not possible.",
+	1043, // "The Storage Controller is unresponsive. The current operation is not possible.",
+	1046, // "An internal timeout has occurred.",
+	1048, // "An MC internal error has occurred.",
+	1069, // "Not enough rendering resources available. Too many concurrent user sessions may cause this issue.",
+}
+
 // ResponseStatus: Final representation of the "status" object in every API response
 type ResponseStatus struct {
 	ResponseType        string

--- a/pkg/regression/regression.go
+++ b/pkg/regression/regression.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/Seagate/seagate-exos-x-api-go/v2/pkg/client"
 	"github.com/Seagate/seagate-exos-x-api-go/v2/pkg/common"
 	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v3"
@@ -17,7 +16,9 @@ import (
 
 // ConfigurationYaml provides configuration credentials for a specific storage controller.
 type ConfigurationYaml struct {
-	Ip        string   `yaml:"ip"`        // The IP Address in dot notation of the storage controller, for example 10.1.2.3
+	MCA_IP    string   `yaml:"mc-a-ip"` // The IP Address in dot notation of the storage controller, for example 10.1.2.3
+	MCB_IP    string   `yaml:"mc-b-ip"` // The IP Address in dot notation of the storage controller, for example 10.1.2.3
+	Addrs     []string `yaml:"mc-ip-addrs"`
 	Protocol  string   `yaml:"protocol"`  // The IP protocol to use, such as http or https
 	Username  string   `yaml:"username"`  // The username used to log into the storage controller
 	Password  string   `yaml:"password"`  // The password used to log into the storage controller
@@ -64,11 +65,6 @@ func NewTestConfig(filename string) (*TestConfig, error) {
 		return nil, err
 	}
 
-	ctx := context.WithValue(context.Background(), client.ContextBasicAuth, client.BasicAuth{
-		UserName: config.Username,
-		Password: config.Password,
-	})
-
 	// Use https as default protocol
 	if config.Protocol == "" {
 		config.Protocol = common.DefaultProtocol
@@ -76,14 +72,16 @@ func NewTestConfig(filename string) (*TestConfig, error) {
 
 	return &TestConfig{
 		StorageController: ConfigurationYaml{
-			Ip:        config.Ip,
+			MCA_IP:    config.MCA_IP,
+			MCB_IP:    config.MCB_IP,
+			Addrs:     config.Addrs,
 			Protocol:  config.Protocol,
 			Username:  config.Username,
 			Password:  config.Password,
 			Initiator: config.Initiator,
 			Pool:      config.Pool,
 		},
-		Ctx: ctx,
+		Ctx: context.Background(),
 	}, nil
 }
 

--- a/pkg/regression/tests.go
+++ b/pkg/regression/tests.go
@@ -28,7 +28,7 @@ func DescribeRegression(text string, body func(*TestContext)) bool {
 func registerTestsInGinkgo(sc *TestContext) {
 	for _, test := range tests {
 		test := test
-		Describe(test.text, func() {
+		Describe(test.text, Ordered, ContinueOnFailure, func() {
 			BeforeEach(func() {
 				sc.Setup()
 			})

--- a/pkg/regression/v2_snapshots.go
+++ b/pkg/regression/v2_snapshots.go
@@ -18,15 +18,22 @@ var _ = DescribeRegression("Snapshot Testing (v2)", func(tc *TestContext) {
 		snap2                       = "snap2"
 	)
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		By("setup client for testing")
 
 		logger := klog.FromContext(tc.Config.Ctx)
 		client = storageapi.NewClient()
-		client.StoreCredentials(tc.Config.StorageController.Ip, tc.Config.StorageController.Protocol, tc.Config.StorageController.Username, tc.Config.StorageController.Password)
+		client.StoreCredentials(tc.Config.StorageController.Addrs, tc.Config.StorageController.Protocol, tc.Config.StorageController.Username, tc.Config.StorageController.Password)
 		err := client.Login(tc.Config.Ctx)
-		client.InitSystemInfo()
-		logger.V(3).Info("Login", "ipaddress", client.Addr, "username", client.Username, "err", err)
+		Expect(err).To(BeNil())
+		logger.V(3).Info("Login", "ipaddress", client.CurrentAddr, "username", client.Username, "err", err)
+	})
+
+	AfterAll(func() {
+		By("logout testing client")
+		err := client.Logout()
+		logger := klog.FromContext(tc.Config.Ctx)
+		logger.V(3).Info("Logout", "ip", client.CurrentAddr, "username", client.Username, "err", err)
 		Expect(err).To(BeNil())
 	})
 

--- a/pkg/regression/v2_system.go
+++ b/pkg/regression/v2_system.go
@@ -14,14 +14,22 @@ var _ = DescribeRegression("System Testing (v2)", func(tc *TestContext) {
 		client *storageapi.Client = nil
 	)
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		By("setup client for testing")
 
 		logger := klog.FromContext(tc.Config.Ctx)
 		client = storageapi.NewClient()
-		client.StoreCredentials(tc.Config.StorageController.Ip, tc.Config.StorageController.Protocol, tc.Config.StorageController.Username, tc.Config.StorageController.Password)
+		client.StoreCredentials(tc.Config.StorageController.Addrs, tc.Config.StorageController.Protocol, tc.Config.StorageController.Username, tc.Config.StorageController.Password)
 		err := client.Login(tc.Config.Ctx)
-		logger.V(3).Info("Login", "ipaddress", client.Addr, "username", client.Username, "err", err)
+		Expect(err).To(BeNil())
+		logger.V(3).Info("Login", "ipaddress", client.CurrentAddr, "username", client.Username, "err", err)
+	})
+
+	AfterAll(func() {
+		By("logout testing client")
+		err := client.Logout()
+		logger := klog.FromContext(tc.Config.Ctx)
+		logger.V(3).Info("Logout", "ip", client.CurrentAddr, "username", client.Username, "err", err)
 		Expect(err).To(BeNil())
 	})
 


### PR DESCRIPTION
Add the ExecuteWithFailover function to wrap openAPI Execute() calls. 

Allow specification of multiple controller ip addresses, During execution of API calls, if api call returns an error, login and retry on the other specified controller, if available. 

Remove previously deprecated SessionValid function in favor of retry logic.

Reconfigures test suite as an "ordered collection" to ensure test order execution, and uses BeforeAll and Afterall calls for login/logout.

Specification of controller IP addresses as a list, and removal of the SessionValid function are breaking changes from the current interface of the library. 