### PR TITLE
fix(map,copy): three ME5-class map/copy failure modes

### DIFF
--- a/pkg/api/volumes.go
+++ b/pkg/api/volumes.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Seagate/seagate-exos-x-api-go/v2/pkg/client"
 	"github.com/Seagate/seagate-exos-x-api-go/v2/pkg/common"
@@ -25,6 +26,26 @@ const (
 	ApiWarning               = 3
 	UngroupedHostsGroupID    = "HGU"
 	UngroupedInitiatorHostID = "HU"
+
+	// copyVolumeVisibilityTimeout bounds how long CopyVolume waits for the
+	// destination volume to appear in ShowVolumes with a populated WWN after
+	// the array has accepted /copy/volume. ME5-class firmware returns 200 OK
+	// from /copy/volume as soon as the copy is scheduled, but the destination
+	// is not yet addressable via /show/volumes/<name> — callers that use the
+	// returned WWN immediately (CSI CreateVolume → GetVolumeWwn) otherwise
+	// emit a volume ID with an empty WWN tail and NodeStageVolume later fails
+	// with DeadlineExceeded.
+	copyVolumeVisibilityTimeout = 30 * time.Second
+	copyVolumeVisibilityPoll    = 500 * time.Millisecond
+
+	// mapVolumeRetryTimeout bounds how long mapVolumeProcess retries when the
+	// array returns -3002 ("command is not supported") from /map/volume.
+	// Empirically, this code is emitted transiently for ~2–20s after a fresh
+	// volume create while controller-to-controller state is propagating; the
+	// identical call with the same headers and session succeeds once the
+	// window closes.
+	mapVolumeRetryTimeout = 30 * time.Second
+	mapVolumeRetryPoll    = 500 * time.Millisecond
 )
 
 // Volume : a mapped volume
@@ -373,28 +394,62 @@ func (client *Client) CreateNickname(name, iqn string) (*common.ResponseStatus, 
 	return response, err
 }
 
-// mapVolumeProcess: Map a volume to an initiator and create a nickname when required by the storage array
+// mapVolumeProcess: Map a volume to an initiator and create a nickname when required by the storage array.
+// Retries transparently when the array returns -3002 "command is not supported"
+// (see CommandNotSupportedErrorCode) — that code is emitted for a short window
+// after a fresh CreateVolume/CopyVolume while controller-to-controller state
+// propagates, and the identical call succeeds once it closes. Any other
+// non-success ReturnCode (apart from the three already-handled well-known
+// codes) is returned as codes.Internal rather than silently swallowed.
 func (client *Client) mapVolumeProcess(volumeName, initiatorName string, lun int) error {
 
 	logger := klog.FromContext(client.Ctx)
 	logger.V(0).Info("trying to map volume", "volume", volumeName, "initiator", initiatorName, "lun", lun)
-	metadata, err := client.MapVolume(volumeName, initiatorName, "rw", lun)
-	if err != nil && metadata == nil {
-		return err
-	}
 
-	logger.Info("status", "ReturnCode", metadata.ReturnCode)
-	if metadata.ReturnCode == common.VolumeNotFoundErrorCode {
-		return status.Errorf(codes.NotFound, "volume %s not found", volumeName)
-	} else if metadata.ReturnCode == common.LUNOverlapErrorCode {
-		return status.Errorf(codes.AlreadyExists, "lun overlap for lun: %d", lun)
-	} else if metadata.ReturnCode == common.InitiatorNicknameOrIdentifierNotFound {
-		return status.Errorf(codes.AlreadyExists, "specified initiator for mapping not found: %s", initiatorName)
-	} else if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
+	deadline := time.Now().Add(mapVolumeRetryTimeout)
+	attempt := 0
+	for {
+		attempt++
+		metadata, err := client.MapVolume(volumeName, initiatorName, "rw", lun)
+		if err != nil && metadata == nil {
+			return err
+		}
 
-	return nil
+		logger.Info("status", "ReturnCode", metadata.ReturnCode, "ResponseType", metadata.ResponseType, "attempt", attempt)
+
+		switch metadata.ReturnCode {
+		case ApiSuccess:
+			if err != nil {
+				return status.Error(codes.Internal, err.Error())
+			}
+			return nil
+		case common.VolumeNotFoundErrorCode:
+			return status.Errorf(codes.NotFound, "volume %s not found", volumeName)
+		case common.LUNOverlapErrorCode:
+			return status.Errorf(codes.AlreadyExists, "lun overlap for lun: %d", lun)
+		case common.InitiatorNicknameOrIdentifierNotFound:
+			return status.Errorf(codes.AlreadyExists, "specified initiator for mapping not found: %s", initiatorName)
+		case common.CommandNotSupportedErrorCode:
+			if time.Now().After(deadline) {
+				return status.Errorf(codes.DeadlineExceeded,
+					"map volume %s to %s lun %d still returning -3002 after %s (attempt %d); array likely rejected the mapping",
+					volumeName, initiatorName, lun, mapVolumeRetryTimeout, attempt)
+			}
+			logger.V(1).Info("map volume returned -3002, retrying", "volume", volumeName, "initiator", initiatorName, "lun", lun, "attempt", attempt)
+			time.Sleep(mapVolumeRetryPoll)
+			continue
+		default:
+			if metadata.ResponseTypeNumeric == ApiError {
+				return status.Errorf(codes.Internal,
+					"map volume %s to %s lun %d failed: ReturnCode=%d Response=%q",
+					volumeName, initiatorName, lun, metadata.ReturnCode, metadata.Response)
+			}
+			if err != nil {
+				return status.Error(codes.Internal, err.Error())
+			}
+			return nil
+		}
+	}
 }
 
 // UnmapVolume : unmap a volume from an initiator
@@ -439,13 +494,54 @@ func (client *Client) ExpandVolume(name, size string) (*common.ResponseStatus, e
 	return status, err
 }
 
-// CopyVolume : create an new volume by copying another one or a snapshot
+// CopyVolume : create an new volume by copying another one or a snapshot.
+// On ApiSuccess, blocks until the destination volume is visible in
+// ShowVolumes with a populated WWN (see copyVolumeVisibilityTimeout). The
+// array accepts /copy/volume before the destination is addressable by name;
+// callers that read back the volume immediately (e.g. GetVolumeWwn) would
+// otherwise observe -10058 "volume does not exist" and silently propagate an
+// empty WWN.
 func (client *Client) CopyVolume(sourceName string, destinationName string, pool string) (*common.ResponseStatus, error) {
 
 	logger := klog.FromContext(client.Ctx)
-	_, status, httpRes, err := ExecuteWithFailover(client.apiClient.DefaultApi.CopyVolumeDestinationPoolNameSourceGet(client.Ctx, pool, destinationName, sourceName).Execute, client)
+	_, respStatus, httpRes, err := ExecuteWithFailover(client.apiClient.DefaultApi.CopyVolumeDestinationPoolNameSourceGet(client.Ctx, pool, destinationName, sourceName).Execute, client)
 	logger.V(2).Info("copy volume", "destination", destinationName, "source", sourceName, "pool", pool, "http", httpRes.Status)
-	return status, err
+	if err != nil || respStatus == nil || respStatus.ResponseTypeNumeric != ApiSuccess {
+		return respStatus, err
+	}
+
+	if waitErr := client.waitForVolumeVisible(destinationName); waitErr != nil {
+		return respStatus, waitErr
+	}
+	return respStatus, nil
+}
+
+// waitForVolumeVisible polls ShowVolumes until the named volume is returned
+// with a non-empty WWN or copyVolumeVisibilityTimeout elapses. Used after
+// CopyVolume to close the post-create propagation window in which the array
+// reports "volume does not exist" for a volume it has already accepted.
+func (client *Client) waitForVolumeVisible(name string) error {
+	logger := klog.FromContext(client.Ctx)
+	deadline := time.Now().Add(copyVolumeVisibilityTimeout)
+	attempt := 0
+	for {
+		attempt++
+		vols, _, err := client.ShowVolumes(name)
+		if err == nil {
+			for _, v := range vols {
+				if v.VolumeName == name && v.Wwn != "" {
+					logger.V(2).Info("volume visible after copy", "volume", name, "attempt", attempt, "wwn", v.Wwn)
+					return nil
+				}
+			}
+		} else {
+			logger.V(4).Info("volume not yet visible after copy", "volume", name, "attempt", attempt, "err", err)
+		}
+		if time.Now().After(deadline) {
+			return status.Errorf(codes.DeadlineExceeded, "volume %s not visible after copy within %s (last err: %v)", name, copyVolumeVisibilityTimeout, err)
+		}
+		time.Sleep(copyVolumeVisibilityPoll)
+	}
 }
 
 // DeleteVolume : deletes a volume

--- a/pkg/api/volumes.go
+++ b/pkg/api/volumes.go
@@ -408,9 +408,26 @@ func (client *Client) UnmapVolume(name, initiator string) (*common.ResponseStatu
 		return status, err
 	}
 
-	_, status, httpRes, err := ExecuteWithFailover(client.apiClient.DefaultApi.UnmapVolumeInitiatorNamesGet(client.Ctx, initiator, name).Execute, client)
-	logger.V(2).Info("unmap volume", "name", name, "initiator", initiator, "http", httpRes.Status)
+	target := client.resolveMapTarget(initiator)
+	_, status, httpRes, err := ExecuteWithFailover(client.apiClient.DefaultApi.UnmapVolumeInitiatorNamesGet(client.Ctx, target, name).Execute, client)
+	logger.V(2).Info("unmap volume", "name", name, "initiator", initiator, "target", target, "http", httpRes.Status)
 	return status, err
+}
+
+// resolveMapTarget returns the ME5024 identifier to use in the initiator slot
+// of /map/volume and /unmap/volume calls. When the initiator is a member of a
+// host record, the ME5024 silently no-ops map calls that reference the raw
+// IQN (the initiator is considered "owned" by the host). Passing the host's
+// name resolves to that host record and produces a working map entry with
+// identical LUN and access semantics. If the initiator is ungrouped, or the
+// lookup fails, the original initiator identifier is returned so the caller's
+// behavior matches pre-patch releases.
+func (client *Client) resolveMapTarget(initiator string) string {
+	_, host, err := client.GetInitiatorHostGroup(initiator)
+	if err != nil || host == "" {
+		return initiator
+	}
+	return host
 }
 
 // ExpandVolume : extend a volume if there is enough space in the disk group
@@ -440,7 +457,14 @@ func (client *Client) DeleteVolume(name string) (*common.ResponseStatus, error) 
 	return status, err
 }
 
-// PublishVolume: Attach a volume to an initiator, return mapped lun or error
+// PublishVolume: Attach a volume to an initiator, return mapped lun or error.
+//
+// When an initiator belongs to a host record on the array, the map call is
+// issued against the host's name rather than the raw IQN — the ME5024
+// silently no-ops initiator-level map requests for initiators that are
+// already owned by a host (see resolveMapTarget). Multiple initiators on the
+// same host therefore produce a single host-level map entry instead of a
+// duplicate per-initiator attempt.
 func (client *Client) PublishVolume(volumeId string, initiators []string) (string, error) {
 
 	logger := klog.FromContext(client.Ctx)
@@ -452,19 +476,29 @@ func (client *Client) PublishVolume(volumeId string, initiators []string) (strin
 
 	logger.Info("using LUN", "lun", lun)
 
-	mappingSuccessful := false
+	seen := make(map[string]struct{}, len(initiators))
+	targets := make([]string, 0, len(initiators))
 	for _, initiator := range initiators {
-		if err = client.mapVolumeProcess(volumeId, initiator, lun); err != nil {
-			logger.Error(err, "mapping error", "volume", volumeId, "initiator", initiator, "LUN", lun)
+		t := client.resolveMapTarget(initiator)
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		targets = append(targets, t)
+	}
+
+	mappingSuccessful := false
+	for _, target := range targets {
+		if err = client.mapVolumeProcess(volumeId, target, lun); err != nil {
+			logger.Error(err, "mapping error", "volume", volumeId, "target", target, "LUN", lun)
 		} else {
 			mappingSuccessful = true
-			logger.Info("successfully mapped", "volume", volumeId, "initiator", initiators, "lun", lun)
+			logger.Info("successfully mapped", "volume", volumeId, "target", target, "lun", lun)
 		}
 	}
 
 	if mappingSuccessful {
 		return strconv.Itoa(lun), nil
-	} else {
-		return "", fmt.Errorf("error mapping volume (%s), no initiators were mapped successfully", volumeId)
 	}
+	return "", fmt.Errorf("error mapping volume (%s), no targets were mapped successfully", volumeId)
 }

--- a/pkg/common/response.go
+++ b/pkg/common/response.go
@@ -11,7 +11,12 @@ import (
 
 // Exos X Storage API Error Codes
 const (
-	InvalidSessionKey                     = 2
+	InvalidSessionKey = 2
+	// CommandNotSupportedErrorCode is returned transiently by map/volume when the
+	// target volume was created too recently for controller-to-controller state
+	// to have propagated. Retrying after a brief backoff clears it; the array
+	// does not distinguish this transient case from a permanent refusal.
+	CommandNotSupportedErrorCode          = -3002
 	LUNOverlapErrorCode                   = -3177
 	SnapshotNotFoundErrorCode             = -10050
 	BadInputParam                         = -10058


### PR DESCRIPTION
## Summary

Three independent failure modes that all surface on ME5-class firmware
when the array is driven through `/map/volume` and `/copy/volume` by
the CSI controller. Each reproduces reliably; each has been observed
via controller logs and cross-verified with the array's REST API.

The patches stack cleanly and share enough context that I've left them
as two commits in this PR rather than three — the first adds
host-record map routing, and the second adds the two post-create
state-propagation fixes that only became visible once the map routing
was correct. If you'd prefer them as three separate PRs, happy to
split.

## The bugs

### 1. Host-record map calls silently no-op when the initiator is owned

`/api/map/volume/access/rw/lun/N/initiator/<IQN>/<vol>` returns `200 OK`
but the mapping never materializes when `<IQN>` is a member of a host
record on the array. The array considers the initiator "owned" by the
host and applies mappings only when they reference the host name. The
caller gets `ResponseType=Success ReturnCode=0`, `PublishVolume` logs
`"successfully mapped"`, and `NodeStageVolume` subsequently fails with
`stat /dev/disk/by-path/...-lun-N: no such file or directory` because
the expected by-path device never appears.

**Fix (`volumes.go`):** add `resolveMapTarget(initiator)` that consults
`GetInitiatorHostGroup` and returns the host's name when the initiator
is owned by one, falling back to the raw IQN for ungrouped initiators.
`PublishVolume` resolves each initiator, dedupes the resulting targets,
and maps once per host. `UnmapVolume` applies the same resolution so
the symmetric tear-down hits the same entry the map call created.

Host-group-level mapping is not emitted: the
`/api/map/volume/.../initiator/` endpoint rejects host-group names with
`"specified initiator not found"`, and the generated client exposes no
host-group-scoped map endpoint. Host-level mapping is sufficient
because `PublishVolume` is called per node and each node's initiators
live under exactly one host record.

### 2. `/copy/volume` returns before the destination is readable

`/api/copy/volume/...` returns `ResponseType=Success` as soon as the
copy is scheduled, but the destination volume is not yet addressable by
name — `/show/volumes/<name>` responds with `"Bad parameter(s) were
specified. ... The specified volume does not exist."` (`ReturnCode=-10058`)
for 500ms–several seconds after copy acceptance. Callers that read back
the volume's WWN immediately (the CSI `CreateVolume → GetVolumeWwn`
chain) observe an empty string and propagate a volume ID with an empty
WWN tail. `NodeStageVolume` then times out on a multipath lookup that
can never resolve.

The existing regression test already acknowledged this indirectly by
sleeping two seconds after every `CopyVolume` in
`pkg/regression/v2_volumes.go`.

**Fix (`volumes.go`):** `CopyVolume` now blocks until
`ShowVolumes(destinationName)` returns the new volume with a non-empty
WWN, bounded by `copyVolumeVisibilityTimeout` (30s) with a 500ms poll.
On timeout it returns a `codes.DeadlineExceeded` with the last observed
error.

### 3. `/map/volume` returns `-3002` transiently after a fresh copy

With (1) fixed, `/api/map/volume/.../initiator/<host>/<vol>` reliably
fails with `ReturnCode=-3002 ResponseType=Error "Command is not
supported"` when called within ~2–20 seconds of a fresh `/copy/volume`
for the same destination, and reliably succeeds with the identical
URL/headers/session once the window closes. `mapVolumeProcess` has no
case for `-3002` in its if-ladder, so the unrecognized code falls
through to `return nil`. The controller logs `"successfully mapped"`
while the array actually refused the mapping, and the node-side
`MapPodDevice` then fails with `no such file or directory`.

**Fix (`response.go`, `volumes.go`):**

- New named constant `CommandNotSupportedErrorCode = -3002`.
- `mapVolumeProcess` is wrapped in a bounded retry loop
  (`mapVolumeRetryTimeout = 30s`, `mapVolumeRetryPoll = 500ms`) that
  re-issues the map call on `-3002`. On timeout it returns
  `codes.DeadlineExceeded`.
- The if-ladder is converted to a `switch` with an explicit `default`
  that returns `codes.Internal` when `ResponseTypeNumeric == ApiError`
  and the code is unrecognized, so a future unexpected `-N` cannot
  re-create the silent-success class of bug.

## Validation

End-to-end validated against an ME5024-backed Kubernetes cluster using
a Velero snapshot-move backup path (`snapshotMoveData: true`) on a
~100 GiB Windows VM. Before this PR the exposer pod stayed in
`ContainerCreating` with `rpc error: code = Internal desc = error
mapping volume ..., no targets were mapped successfully`; with the PR
applied the DataUpload reaches `InProgress` and streams real filesystem
content through Kopia to object storage.

Controller log excerpt on the happy path (identifiers redacted):

```
"volume visible after copy" volume="<vol>" attempt=1 wwn="<wwn>"
"map volume returned -3002, retrying" ... attempt=1 ... attempt=40
"successfully mapped" volume="<vol>" target="<host-record>" lun=<N>
```

A companion PR against `Seagate/seagate-exos-x-csi` covers an
independent iSCSI LUN-reuse cleanup that is required on the node side
for the full end-to-end flow.

## Compatibility

- All three fixes are additive; no existing API surface or wire-format
  changes. All existing callers of `CopyVolume` / `PublishVolume` /
  `UnmapVolume` see the same return types.
- The host-record routing is transparent for setups that do not use
  host records (`GetInitiatorHostGroup` returns empty, callers keep
  receiving the raw IQN path).
- The retry loops default to 30s which is well inside existing CSI RPC
  deadlines; in practice the map-retry resolves in ~5-25s and the
  copy-wait in ~500ms-2s.
